### PR TITLE
Fix nested object FormData in post requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chec.io/commerce",
-  "version": "2.0.0",
+  "version": "2.0.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/features/checkout.js
+++ b/src/features/checkout.js
@@ -37,7 +37,14 @@ class Checkout {
    * @return {Promise}
    */
   capture(token, data) {
-    return this.commerce.request(`checkouts/${token}`, 'post', data);
+    return this.commerce
+      .request(`checkouts/${token}`, 'post', data)
+      .then(response => {
+        // Clear the cart ID on success
+        this.commerce.cart.refresh();
+        // Return the original response
+        return response;
+      });
   }
 
   /**

--- a/src/features/checkout.js
+++ b/src/features/checkout.js
@@ -40,7 +40,7 @@ class Checkout {
     return this.commerce
       .request(`checkouts/${token}`, 'post', data)
       .then(response => {
-        // Clear the cart ID on success
+        // Refresh the cart on success
         this.commerce.cart.refresh();
         // Return the original response
         return response;

--- a/src/features/products.js
+++ b/src/features/products.js
@@ -11,10 +11,10 @@ class Products {
   /**
    * List products for the current merchant
    *
-   * @param {object} params
+   * @param {object|null} params
    * @return {Promise}
    */
-  list(params) {
+  list(params = null) {
     return this.commerce.request('products', 'get', params);
   }
 

--- a/src/features/tests/cart-test.js
+++ b/src/features/tests/cart-test.js
@@ -40,6 +40,7 @@ beforeEach(() => {
   };
 
   commerceImpl.request = Commerce.prototype.request.bind(commerceImpl);
+  commerceImpl._serialize = Commerce.prototype._serialize.bind(commerceImpl);
 
   MockCommerce.mockImplementation(() => commerceImpl);
 

--- a/src/features/tests/checkout-test.js
+++ b/src/features/tests/checkout-test.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 
   // Commerce mock internals
   requestMock = jest.fn();
-  requestMock.mockReturnValue('return');
+  requestMock.mockReturnValue(new Promise(() => 'return'));
 
   Commerce.mockImplementation(() => {
     return {
@@ -50,7 +50,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/foo', 'get', {
         a: 'b',
       });
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -67,7 +67,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/foo123', 'post', {
         a: 'b',
       });
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -83,7 +83,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/abc123/check/paypal/payment',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -95,7 +95,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/abc123/check/paypal/captured',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -109,7 +109,7 @@ describe('Checkout', () => {
       );
 
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/qw3rt1/receipt');
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -125,7 +125,7 @@ describe('Checkout', () => {
         'get',
         { foo: 'baz' },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -139,7 +139,7 @@ describe('Checkout', () => {
       );
 
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/foobar/fields');
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -153,7 +153,7 @@ describe('Checkout', () => {
         'get',
         { zone: 'Cuba' },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -165,7 +165,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/b0b/helper/location_from_ip',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
 
     it('proxies the request method using the provided IP address string', () => {
@@ -175,7 +175,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/b0b/helper/location_from_ip?ip_address=127.0.0.1',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -191,7 +191,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/a1s2d3/check/is_free',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -207,7 +207,7 @@ describe('Checkout', () => {
         'get',
         { hello: 'world' },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -221,7 +221,7 @@ describe('Checkout', () => {
         'get',
         { code: 'A1D2' },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -237,7 +237,7 @@ describe('Checkout', () => {
         'get',
         { method: 'A1D2' },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -251,7 +251,7 @@ describe('Checkout', () => {
         'get',
         { a: 'b' },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -267,7 +267,7 @@ describe('Checkout', () => {
         'get',
         { quantity: 25 },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -283,7 +283,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo123/helper/validation',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -299,7 +299,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo-123-bar/live',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -315,7 +315,7 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/tokens/foo-123-bar',
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 
@@ -329,7 +329,7 @@ describe('Checkout', () => {
         'get',
         { card: 'BAR123' },
       );
-      expect(returnValue).toBe('return');
+      returnValue.then(result => expect(result).toBe('return'));
     });
   });
 });

--- a/src/features/tests/checkout-test.js
+++ b/src/features/tests/checkout-test.js
@@ -2,6 +2,7 @@
 
 import Checkout from '../checkout';
 import Commerce from '../../commerce';
+import '@babel/polyfill';
 
 jest.mock('../../commerce');
 
@@ -9,16 +10,21 @@ let requestMock;
 let mockCommerce;
 let mockCallback;
 let mockErrorCallback;
+let refreshCartMock;
 
 beforeEach(() => {
   Commerce.mockClear();
 
   // Commerce mock internals
+  refreshCartMock = jest.fn();
   requestMock = jest.fn();
-  requestMock.mockReturnValue(new Promise(() => 'return'));
+  requestMock.mockReturnValue(Promise.resolve('return'));
 
   Commerce.mockImplementation(() => {
     return {
+      cart: {
+        refresh: refreshCartMock,
+      },
       request: requestMock,
     };
   });
@@ -32,7 +38,7 @@ beforeEach(() => {
 
 describe('Checkout', () => {
   describe('protect', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       requestMock.mockReturnValueOnce(Promise.resolve({}));
 
       const checkout = new Checkout(mockCommerce);
@@ -43,19 +49,20 @@ describe('Checkout', () => {
   });
 
   describe('generateToken', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.generateToken('foo', { a: 'b' });
 
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/foo', 'get', {
         a: 'b',
       });
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('capture', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method and refreshes the cart', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.capture(
         'foo123',
@@ -67,12 +74,14 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/foo123', 'post', {
         a: 'b',
       });
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
+      expect(refreshCartMock).toHaveBeenCalled();
     });
   });
 
   describe('checkPaypalStatus', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkPaypalStatus(
         'abc123',
@@ -83,24 +92,26 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/abc123/check/paypal/payment',
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('checkPaypalOrderCaptured', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkPaypalOrderCaptured('abc123');
 
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/abc123/check/paypal/captured',
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('receipt', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.receipt(
         'qw3rt1',
@@ -109,12 +120,13 @@ describe('Checkout', () => {
       );
 
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/qw3rt1/receipt');
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('checkPayWhatYouWant', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkPayWhatYouWant('bar321', {
         foo: 'baz',
@@ -125,12 +137,13 @@ describe('Checkout', () => {
         'get',
         { foo: 'baz' },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('fields', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.fields(
         'foobar',
@@ -139,12 +152,13 @@ describe('Checkout', () => {
       );
 
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/foobar/fields');
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('setTaxZone', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.setTaxZone('b1lly', { zone: 'Cuba' });
 
@@ -153,34 +167,37 @@ describe('Checkout', () => {
         'get',
         { zone: 'Cuba' },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('getLocationFromIP', () => {
-    it('proxies the request method without a given IP', () => {
+    it('proxies the request method without a given IP', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.getLocationFromIP('b0b');
 
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/b0b/helper/location_from_ip',
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
 
-    it('proxies the request method using the provided IP address string', () => {
+    it('proxies the request method using the provided IP address string', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.getLocationFromIP('b0b', '127.0.0.1');
 
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/b0b/helper/location_from_ip?ip_address=127.0.0.1',
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('isFree', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.isFree(
         'a1s2d3',
@@ -191,12 +208,13 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/a1s2d3/check/is_free',
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('checkVariant', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkVariant('a1s2d3', 'h1', {
         hello: 'world',
@@ -207,12 +225,13 @@ describe('Checkout', () => {
         'get',
         { hello: 'world' },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('checkDiscount', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkDiscount('foo123', { code: 'A1D2' });
 
@@ -221,12 +240,13 @@ describe('Checkout', () => {
         'get',
         { code: 'A1D2' },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('checkShippingOption', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkShippingOption('foo123', {
         method: 'A1D2',
@@ -237,12 +257,13 @@ describe('Checkout', () => {
         'get',
         { method: 'A1D2' },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('getShippingOptions', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.getShippingOptions('foo123', { a: 'b' });
 
@@ -251,12 +272,13 @@ describe('Checkout', () => {
         'get',
         { a: 'b' },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('checkQuantity', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkQuantity('foo123', 'bar234', {
         quantity: 25,
@@ -267,12 +289,13 @@ describe('Checkout', () => {
         'get',
         { quantity: 25 },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('helperValidation', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.helperValidation(
         'foo123',
@@ -283,12 +306,13 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo123/helper/validation',
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('getLive', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.getLive(
         'foo-123-bar',
@@ -299,12 +323,13 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo-123-bar/live',
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 
   describe('getToken', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.getToken(
         'foo-123-bar',
@@ -320,7 +345,7 @@ describe('Checkout', () => {
   });
 
   describe('checkGiftcard', () => {
-    it('proxies the request method', () => {
+    it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.checkGiftcard('xkcd', { card: 'BAR123' });
 
@@ -329,7 +354,8 @@ describe('Checkout', () => {
         'get',
         { card: 'BAR123' },
       );
-      returnValue.then(result => expect(result).toBe('return'));
+      const result = await returnValue;
+      expect(result).toBe('return');
     });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import '@babel/polyfill';
 import Commerce from './commerce';
 
 module.exports = Commerce;

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,17 +1,24 @@
+import Commerce from './commerce';
+
 class Storage {
-  //maybe move to data store later
-  constructor(c) {
-    this.c = c;
+  /**
+   * @param {Commerce} commerce
+   */
+  constructor(commerce) {
+    this.commerce = commerce;
   }
 
   set(key, value, days) {
     let path;
     let expires = '';
 
-    if (typeof this.c.options.config.cookie_path === 'undefined') {
+    if (
+      !this.commerce.options.config ||
+      typeof this.commerce.options.config.cookie_path === 'undefined'
+    ) {
       path = '/';
     } else {
-      path = this.c.options.config.cookie_path;
+      path = this.commerce.options.config.cookie_path;
     }
 
     if (days) {

--- a/src/tests/commerce-test.js
+++ b/src/tests/commerce-test.js
@@ -210,4 +210,76 @@ describe('Commerce', () => {
       });
     });
   });
+
+  describe('_serialize', () => {
+    it('converts a set of key value pairs to FormData', () => {
+      const input = { foo: 'bar', bar: 'baz' };
+      const commerce = new Commerce('foo');
+      const result = commerce._serialize(input);
+
+      expect(commerce._serialize(input)).toBeInstanceOf(FormData);
+      expect(result.get('foo')).toBe('bar');
+      expect(result.get('bar')).toBe('baz');
+    });
+
+    it('handles numbers', () => {
+      const input = { id: 123 };
+      const commerce = new Commerce('foo');
+      const result = commerce._serialize(input);
+
+      expect(result.get('id')).toBe('123'); // Always strings!
+    });
+
+    it('handles booleans', () => {
+      const input = { is_free: true };
+      const commerce = new Commerce('foo');
+      const result = commerce._serialize(input);
+
+      expect(result.get('is_free')).toBe('true'); // Always strings!
+    });
+
+    it('handles nested objects', () => {
+      const input = {
+        conditionals: {
+          is_free: true,
+          prefix: 'sdk',
+          extra: {
+            for: 'the sake of it',
+          },
+        },
+      };
+      const commerce = new Commerce('foo');
+      const result = commerce._serialize(input);
+
+      expect(result.get('conditionals[is_free]')).toBe('true');
+      expect(result.get('conditionals[prefix]')).toBe('sdk');
+      expect(result.get('conditionals[extra][for]')).toBe('the sake of it');
+    });
+
+    it('handles nested arrays', () => {
+      const input = {
+        products: [
+          {
+            name: 'T-shirt',
+          },
+          {
+            name: 'JavaScript SDK',
+          },
+          {
+            variants: [
+              {
+                name: 'Something',
+              },
+            ],
+          },
+        ],
+      };
+      const commerce = new Commerce('foo');
+      const result = commerce._serialize(input);
+
+      expect(result.get('products[0][name]')).toBe('T-shirt');
+      expect(result.get('products[1][name]')).toBe('JavaScript SDK');
+      expect(result.get('products[2][variants][0][name]')).toBe('Something');
+    });
+  });
 });


### PR DESCRIPTION
Allows nested objects or arrays to be correctly encoded as FormData for post requests.

Also:

* allows the params argument for products.list() to be optional.
* clears the cart ID after a successful checkout capture
* adds type hinting doc blocks to settings component