### PR TITLE
Use CustomEvent Interface

### DIFF
--- a/src/commerce.js
+++ b/src/commerce.js
@@ -5,8 +5,10 @@ import { consoleHelper, debuggerOnNotice } from './console';
 import axios from 'axios';
 
 const defaultEventCallback = e => {
-  const _e = document.createEvent('CustomEvent');
-  _e.initCustomEvent(`Commercejs.${e}`, false, false, this);
+  const _e = new CustomEvent(`Commercejs.${e}`, {
+    bubbles: false,
+    cancelable: false,
+  });
   return window.dispatchEvent(_e);
 };
 


### PR DESCRIPTION
- replace `createEvent` with `CustomEvent` interface, many methods used with `createEvent` are deprecated such as `initCustomEvent`
- constructs `CustomEvent` object, and dispatches with same `bubbles` and `cancelable` configurations as before by providing fields from the [EventInit](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event) dictionary.(https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Parameters)
