### PR TITLE
allow configuring of X-Chec-Agent header to make it function with live api.v1

### DIFF
--- a/src/commerce.js
+++ b/src/commerce.js
@@ -82,7 +82,7 @@ class Commerce {
   request(endpoint, method = 'get', data = null, returnFullResponse = false) {
     const headers = {
       'X-Authorization': this.options.publicKey,
-      'X-Chec-Agent': 'commerce.js/v2',
+      'X-Chec-Agent': this.options.xChecAgent || 'commerce.js/v2',
     };
 
     // Let axios serialize get request payloads


### PR DESCRIPTION
Allow configuring of request header, `X-Chec-Agent`. Right now, the live version of the api.v1 only sets the `IS_COMMERCEJS` flag to true if the `X-Chec-Agent` is `"commerce.js/v1”` (on the `live` branch in `api.v1` https://github.com/chec/api.v1/blob/live/api/Providers/ChecApiAuth.php#L52), however the **_v2_** `commerce.js` has the value for the `X-Chec-Agent` header hardcoded as `“commerce.js/v2”`, thus not allowing the `IS_COMMERCEJS` flag to be set to true which in turn does not allow the endpoints to return the `_event` property in the responses that are responsible for allowing `commerce.js` to call the `defaultEventCallback` (see https://github.com/chec/commerce.js/blob/master/src/commerce.js#L7) distributing the events from the backend onto the client side. 