### PR TITLE
before attempting to destruct _event from response.data check if it i…

### DIFF
--- a/src/commerce.js
+++ b/src/commerce.js
@@ -118,6 +118,9 @@ class Commerce {
     const { eventCallback } = this.options;
     return promise.then(response => {
       if (response.status >= 200 && response.status < 300) {
+        if (response.data.constructor === 'Array') {
+          return response.data;
+        }
         const { _event, ...otherData } = response.data;
 
         if (typeof _event === 'string' && typeof eventCallback === 'function') {

--- a/src/commerce.js
+++ b/src/commerce.js
@@ -118,7 +118,7 @@ class Commerce {
     const { eventCallback } = this.options;
     return promise.then(response => {
       if (response.status >= 200 && response.status < 300) {
-        if (response.data.constructor === 'Array') {
+        if (typeof response.data !== 'object' || Array.isArray(response.data)) {
           return response.data;
         }
         const { _event, ...otherData } = response.data;


### PR DESCRIPTION
Before attempting to destruct `_event` prop from response.data check if it is an Array to prevent from changing response.data's type as an array from using `...rest` operator when destructing `_event` property.

This is an issue because on the `checkouts/{token}/helper/shipping_options?country=` endpoint an `Array` is returned from the server thus making `response.data` an Array. After destructing out `_events` from it, and spreading the rest of the contents, it changes the constructor prototype to `Object`, breaking somethings on the front-end. 