### PR TITLE
Restore v1 id behaviour and reduce number of cart requests

### DIFF
--- a/jest.init.js
+++ b/jest.init.js
@@ -1,0 +1,1 @@
+import '@babel/polyfill';

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "rollup-plugin-node-resolve": "^5.2.0"
   },
   "jest": {
-    "testRegex": ".*-test.jsx?$"
+    "testRegex": ".*-test.jsx?$",
+    "setupFiles": ["<rootDir>/jest.init.js"]
   },
   "babel": {
     "presets": [

--- a/src/commerce.js
+++ b/src/commerce.js
@@ -106,9 +106,10 @@ class Commerce {
 
       // Reject the promise by throwing an error
       this.error(response);
-      throw new Error(
-        `Unsuccessful response (${response.status}: ${response.statusText}) received`,
-      );
+      throw {
+        message: `Unsuccessful response (${response.status}: ${response.statusText}) received`,
+        response,
+      };
     });
   }
 }

--- a/src/features/tests/cart-test.js
+++ b/src/features/tests/cart-test.js
@@ -2,7 +2,6 @@
 jest.mock('axios');
 jest.mock('../../commerce');
 
-import '@babel/polyfill';
 import Cart from '../cart';
 import MockCommerce from '../../commerce';
 import axios from 'axios';
@@ -32,6 +31,7 @@ beforeEach(() => {
     cart: {
       cart_id: null,
     },
+    error(response) {},
     event: eventMock,
     storage: {
       get: storageGetMock,
@@ -57,33 +57,86 @@ beforeEach(() => {
 
 describe('Cart', () => {
   describe('id', () => {
-    it('initializes a new ID when none is stored', async () => {
+    it('does not initialise a new ID when none is stored', () => {
       storageGetMock.mockReturnValue(null);
 
       const cart = new Cart(mockCommerce);
 
-      await cart.id();
-
+      expect(cart.id()).toBe(null);
       expect(mockCommerce.storage.get).toHaveBeenCalled();
-      // Ensure that `Cart.refresh()` was called
-      expect(axios).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: 'carts',
-        }),
-      );
+      expect(axios).not.toHaveBeenCalled();
     });
 
-    it('initializes from the stored ID', async () => {
+    it('returns a stored ID', async () => {
       storageGetMock.mockReturnValue('123');
 
       const cart = new Cart(mockCommerce);
 
-      await cart.id();
+      expect(cart.id()).toBe('123');
+      expect(mockCommerce.storage.get).toHaveBeenCalled();
+    });
+  });
+
+  describe('request', () => {
+    it('runs refresh if no cart ID is available', async () => {
+      const cart = new Cart(mockCommerce);
+      const refreshSpy = jest.spyOn(cart, 'refresh');
+
+      await cart.request();
+
+      expect(refreshSpy).toHaveBeenCalled();
+    });
+
+    it('does not refresh if the cart ID is available', async () => {
+      storageGetMock.mockReturnValue('123');
+
+      const cart = new Cart(mockCommerce);
+      const refreshSpy = jest.spyOn(cart, 'refresh');
+
+      await cart.request();
 
       expect(mockCommerce.storage.get).toHaveBeenCalled();
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(axios).toHaveBeenCalledTimes(1);
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
           url: 'carts/123',
+          method: 'get',
+        }),
+      );
+    });
+
+    it('will refresh if a 404 is returned from a request', async () => {
+      axios.mockClear();
+      axios
+        .mockImplementationOnce(() => Promise.resolve({ status: 404 }))
+        .mockImplementation(() =>
+          Promise.resolve({ status: 200, data: { id: '12345' } }),
+        );
+
+      storageGetMock.mockReturnValue('123');
+
+      const cart = new Cart(mockCommerce);
+      const refreshSpy = jest.spyOn(cart, 'refresh');
+
+      await cart.request();
+
+      expect(mockCommerce.storage.get).toHaveBeenCalled();
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'carts/123',
+          method: 'get',
+        }),
+      );
+      expect(mockCommerce.storage.set).toHaveBeenCalledWith(
+        expect.anything(),
+        '12345',
+        expect.anything(),
+      );
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'carts/12345',
           method: 'get',
         }),
       );
@@ -100,14 +153,6 @@ describe('Cart', () => {
         '12345',
         30,
       );
-    });
-  });
-
-  describe('id', () => {
-    it('returns the cart ID', async () => {
-      const cart = new Cart(mockCommerce);
-
-      expect(await cart.id()).toBe('12345');
     });
   });
 

--- a/src/tests/commerce-test.js
+++ b/src/tests/commerce-test.js
@@ -1,12 +1,9 @@
 /* global describe, it, expect */
 jest.mock('axios');
 
-import '@babel/polyfill';
-
 import Commerce from '../commerce';
 import Features from '../features';
 import Storage from '../storage';
-
 import axios from 'axios';
 
 describe('Commerce', () => {


### PR DESCRIPTION
This alters the id method to return only an ID if it's available and updates the request method to fetch an ID (with a refresh call) if one is not available