### PR TITLE
Fix console debugger: now runs on all promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chec/commerce.js",
-  "version": "2.0.0-beta4",
+  "version": "2.0.0-beta5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -782,6 +782,15 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/plugin-transform-runtime": "^7.7.4",
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.2",
+    "@babel/runtime": "^7.7.4",
     "babel-preset-minify": "^0.5.1",
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",

--- a/src/commerce.js
+++ b/src/commerce.js
@@ -51,10 +51,13 @@ class Commerce {
     if (!this.consoleHelper || !this.options.debug) {
       return;
     }
-    const type = `[${response.status}] Type: ${response.statusText}`;
+    const innerResponse = response.response;
+    const type = `[${innerResponse.status}] Type: ${innerResponse.statusText}`;
     const msg =
-      typeof response.data === 'string' ? response.data : response.statusText;
-    return this.consoleHelper('error', type, msg, response);
+      typeof innerResponse.data === 'string'
+        ? innerResponse.data
+        : innerResponse.statusText;
+    return this.consoleHelper('error', type, msg, innerResponse.data);
   }
 
   /**
@@ -122,27 +125,50 @@ class Commerce {
     }
 
     const { eventCallback } = this.options;
-    return promise.then(response => {
-      if (response.status >= 200 && response.status < 300) {
-        if (typeof response.data !== 'object' || Array.isArray(response.data)) {
-          return response.data;
-        }
-        const { _event, ...otherData } = response.data;
+    return (
+      promise
+        .then(response => {
+          // Feed the console debugger
+          if (
+            this.consoleHelper &&
+            this.options.debug &&
+            typeof response.data._console === 'object'
+          ) {
+            this.consoleHelper(...response.data._console);
+          }
 
-        if (typeof _event === 'string' && typeof eventCallback === 'function') {
-          eventCallback(_event);
-        }
+          // Handle the response
+          if (response.status >= 200 && response.status < 300) {
+            if (
+              typeof response.data !== 'object' ||
+              Array.isArray(response.data)
+            ) {
+              return response.data;
+            }
+            const { _event, ...otherData } = response.data;
 
-        return otherData;
-      }
+            if (
+              typeof _event === 'string' &&
+              typeof eventCallback === 'function'
+            ) {
+              eventCallback(_event);
+            }
 
-      // Reject the promise by throwing an error
-      this.error(response);
-      throw {
-        message: `Unsuccessful response (${response.status}: ${response.statusText}) received`,
-        response,
-      };
-    });
+            return otherData;
+          }
+        })
+        // Run our own error handler, then wrap the promise rejection in our own error object
+        .catch(error => {
+          this.error(error);
+          throw {
+            message: `Unsuccessful response (${error.response.status}: ${error.response.statusText}) received`,
+            statusCode: error.response.status,
+            statusText: error.response.statusText,
+            data: error.response.data,
+            originalError: error,
+          };
+        })
+    );
   }
 }
 

--- a/src/commerce.js
+++ b/src/commerce.js
@@ -138,24 +138,22 @@ class Commerce {
           }
 
           // Handle the response
-          if (response.status >= 200 && response.status < 300) {
-            if (
-              typeof response.data !== 'object' ||
-              Array.isArray(response.data)
-            ) {
-              return response.data;
-            }
-            const { _event, ...otherData } = response.data;
-
-            if (
-              typeof _event === 'string' &&
-              typeof eventCallback === 'function'
-            ) {
-              eventCallback(_event);
-            }
-
-            return otherData;
+          if (
+            typeof response.data !== 'object' ||
+            Array.isArray(response.data)
+          ) {
+            return response.data;
           }
+          const { _event, ...otherData } = response.data;
+
+          if (
+            typeof _event === 'string' &&
+            typeof eventCallback === 'function'
+          ) {
+            eventCallback(_event);
+          }
+
+          return otherData;
         })
         // Run our own error handler, then wrap the promise rejection in our own error object
         .catch(error => {

--- a/src/features/cart.js
+++ b/src/features/cart.js
@@ -56,7 +56,7 @@ class Cart {
       .request(`carts/${this.id()}${suffix}`, method, data, returnFullRequest)
       .catch(error => {
         // Catch 404 errors that imply the cart ID has expired
-        if (error.response && error.response.status === 404) {
+        if (error.statusCode && error.statusCode === 404) {
           return this.refresh().then(() => {
             // Note that this repetition of the endpoint cannot be extracted as the `.id()` needs to evaluate both times
             return this.commerce.request(

--- a/src/features/tests/cart-test.js
+++ b/src/features/tests/cart-test.js
@@ -110,7 +110,15 @@ describe('Cart', () => {
     it('will refresh if a 404 is returned from a request', async () => {
       axios.mockClear();
       axios
-        .mockImplementationOnce(() => Promise.resolve({ status: 404 }))
+        .mockImplementationOnce(() =>
+          Promise.reject({
+            response: {
+              status: 404,
+              statusText: 'Not found',
+              data: {},
+            },
+          }),
+        )
         .mockImplementation(() =>
           Promise.resolve({ status: 200, data: { id: '12345' } }),
         );

--- a/src/features/tests/checkout-test.js
+++ b/src/features/tests/checkout-test.js
@@ -132,9 +132,7 @@ describe('Checkout', () => {
         foo: 'baz',
       });
 
-      expect(
-        requestMock,
-      ).toHaveBeenLastCalledWith(
+      expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/bar321/check/pay_what_you_want',
         'get',
         { foo: 'baz' },
@@ -277,9 +275,7 @@ describe('Checkout', () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.getShippingOptions('foo123', { a: 'b' });
 
-      expect(
-        requestMock,
-      ).toHaveBeenLastCalledWith(
+      expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo123/helper/shipping_options',
         'get',
         { a: 'b' },
@@ -296,9 +292,7 @@ describe('Checkout', () => {
         quantity: 25,
       });
 
-      expect(
-        requestMock,
-      ).toHaveBeenLastCalledWith(
+      expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo123/check/bar234/quantity',
         'get',
         { quantity: 25 },

--- a/src/features/tests/checkout-test.js
+++ b/src/features/tests/checkout-test.js
@@ -132,7 +132,9 @@ describe('Checkout', () => {
         foo: 'baz',
       });
 
-      expect(requestMock).toHaveBeenLastCalledWith(
+      expect(
+        requestMock,
+      ).toHaveBeenLastCalledWith(
         'checkouts/bar321/check/pay_what_you_want',
         'get',
         { foo: 'baz' },
@@ -165,7 +167,9 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/b1lly/helper/set_tax_zone',
         'get',
-        { zone: 'Cuba' },
+        {
+          zone: 'Cuba',
+        },
       );
       const result = await returnValue;
       expect(result).toBe('return');
@@ -223,7 +227,9 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/a1s2d3/check/h1/variant',
         'get',
-        { hello: 'world' },
+        {
+          hello: 'world',
+        },
       );
       const result = await returnValue;
       expect(result).toBe('return');
@@ -238,7 +244,9 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo123/check/discount',
         'get',
-        { code: 'A1D2' },
+        {
+          code: 'A1D2',
+        },
       );
       const result = await returnValue;
       expect(result).toBe('return');
@@ -255,7 +263,9 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/foo123/check/shipping',
         'get',
-        { method: 'A1D2' },
+        {
+          method: 'A1D2',
+        },
       );
       const result = await returnValue;
       expect(result).toBe('return');
@@ -267,7 +277,9 @@ describe('Checkout', () => {
       const checkout = new Checkout(mockCommerce);
       const returnValue = checkout.getShippingOptions('foo123', { a: 'b' });
 
-      expect(requestMock).toHaveBeenLastCalledWith(
+      expect(
+        requestMock,
+      ).toHaveBeenLastCalledWith(
         'checkouts/foo123/helper/shipping_options',
         'get',
         { a: 'b' },
@@ -284,7 +296,9 @@ describe('Checkout', () => {
         quantity: 25,
       });
 
-      expect(requestMock).toHaveBeenLastCalledWith(
+      expect(
+        requestMock,
+      ).toHaveBeenLastCalledWith(
         'checkouts/foo123/check/bar234/quantity',
         'get',
         { quantity: 25 },
@@ -352,7 +366,9 @@ describe('Checkout', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'checkouts/xkcd/check/giftcard',
         'get',
-        { card: 'BAR123' },
+        {
+          card: 'BAR123',
+        },
       );
       const result = await returnValue;
       expect(result).toBe('return');


### PR DESCRIPTION
Previously was not running on successfully resolved promises, and was expecting a non-Axios format for the error object. The call for the
error handler was in the successful promise resolution, so it was neve  called. This commit fixes both of those issues.

Fixes https://github.com/chec/api.v1/issues/159 and fixes https://github.com/chec/commerce.js/issues/28