### PR TITLE
Use content-type JSON as axios default so that PUT requests work

### DIFF
--- a/src/commerce.js
+++ b/src/commerce.js
@@ -60,45 +60,15 @@ class Commerce {
     return this.consoleHelper('error', type, msg, innerResponse.data);
   }
 
-  /**
-   * Recursively encodes input data into FormData objects
-   *
-   * @param {string|object} input
-   * @param {string|null} keyNamespace
-   * @param {FormData|null} formData
-   * @returns {FormData|string} Eventually returns a FormData object
-   * @private
-   */
-  _serialize(input, keyNamespace = null, formData = null) {
-    // Return non-iterable input immediately
-    if (typeof input !== 'object') {
-      return input;
-    }
-
-    const data = formData || new FormData();
-    for (let key in input) {
-      const dataKey = keyNamespace === null ? key : `${keyNamespace}[${key}]`;
-
-      // Recursively handle nested objects
-      if (typeof input[key] === 'object') {
-        this._serialize(input[key], dataKey, data);
-      } else {
-        data.append(dataKey, input[key]);
-      }
-    }
-
-    return data;
-  }
-
   request(endpoint, method = 'get', data = null, returnFullResponse = false) {
     const headers = {
       'X-Authorization': this.options.publicKey,
       'X-Chec-Agent': 'commerce.js/v2',
     };
 
-    // Let axios serialize get request payloads
+    // Let axios serialize get request payloads as JSON
     const params = method === 'get' ? data : null;
-    const requestBody = method === 'get' ? null : this._serialize(data);
+    const requestBody = method === 'get' ? null : data;
 
     const timeout = this.options.timeoutMs || 60000;
     const axiosConfig = this.options.axiosConfig || {};

--- a/src/features/tests/cart-test.js
+++ b/src/features/tests/cart-test.js
@@ -40,7 +40,6 @@ beforeEach(() => {
   };
 
   commerceImpl.request = Commerce.prototype.request.bind(commerceImpl);
-  commerceImpl._serialize = Commerce.prototype._serialize.bind(commerceImpl);
 
   MockCommerce.mockImplementation(() => commerceImpl);
 
@@ -182,8 +181,7 @@ describe('Cart', () => {
       );
 
       const lastData = axios.mock.calls.pop()[0].data;
-      expect(lastData).toBeInstanceOf(FormData);
-      expect(lastData.get('id')).toBe('bar');
+      expect(lastData.id).toBe('bar');
     });
 
     it('builds a request from given args', async () => {
@@ -201,10 +199,9 @@ describe('Cart', () => {
       );
 
       const lastData = axios.mock.calls.pop()[0].data;
-      expect(lastData).toBeInstanceOf(FormData);
-      expect(lastData.get('id')).toBe('id');
-      expect(lastData.get('quantity')).toBe('6');
-      expect(lastData.get('variant[variant]')).toBe('option');
+      expect(lastData.id).toBe('id');
+      expect(lastData.quantity).toEqual(6);
+      expect(lastData.variant.variant).toBe('option');
     });
   });
 
@@ -266,8 +263,7 @@ describe('Cart', () => {
       );
 
       const lastData = axios.mock.calls.pop()[0].data;
-      expect(lastData).toBeInstanceOf(FormData);
-      expect(lastData.get('foo')).toBe('bar');
+      expect(lastData.foo).toBe('bar');
     });
   });
 

--- a/src/tests/commerce-test.js
+++ b/src/tests/commerce-test.js
@@ -146,8 +146,7 @@ describe('Commerce', () => {
       const data = { test: true };
       commerce.request('test', 'post', data);
 
-      const expectation = new FormData();
-      expectation.set('test', true);
+      const expectation = { test: true };
 
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -213,78 +212,6 @@ describe('Commerce', () => {
       expect(response).toEqual({
         other: 'data',
       });
-    });
-  });
-
-  describe('_serialize', () => {
-    it('converts a set of key value pairs to FormData', () => {
-      const input = { foo: 'bar', bar: 'baz' };
-      const commerce = new Commerce('foo');
-      const result = commerce._serialize(input);
-
-      expect(commerce._serialize(input)).toBeInstanceOf(FormData);
-      expect(result.get('foo')).toBe('bar');
-      expect(result.get('bar')).toBe('baz');
-    });
-
-    it('handles numbers', () => {
-      const input = { id: 123 };
-      const commerce = new Commerce('foo');
-      const result = commerce._serialize(input);
-
-      expect(result.get('id')).toBe('123'); // Always strings!
-    });
-
-    it('handles booleans', () => {
-      const input = { is_free: true };
-      const commerce = new Commerce('foo');
-      const result = commerce._serialize(input);
-
-      expect(result.get('is_free')).toBe('true'); // Always strings!
-    });
-
-    it('handles nested objects', () => {
-      const input = {
-        conditionals: {
-          is_free: true,
-          prefix: 'sdk',
-          extra: {
-            for: 'the sake of it',
-          },
-        },
-      };
-      const commerce = new Commerce('foo');
-      const result = commerce._serialize(input);
-
-      expect(result.get('conditionals[is_free]')).toBe('true');
-      expect(result.get('conditionals[prefix]')).toBe('sdk');
-      expect(result.get('conditionals[extra][for]')).toBe('the sake of it');
-    });
-
-    it('handles nested arrays', () => {
-      const input = {
-        products: [
-          {
-            name: 'T-shirt',
-          },
-          {
-            name: 'JavaScript SDK',
-          },
-          {
-            variants: [
-              {
-                name: 'Something',
-              },
-            ],
-          },
-        ],
-      };
-      const commerce = new Commerce('foo');
-      const result = commerce._serialize(input);
-
-      expect(result.get('products[0][name]')).toBe('T-shirt');
-      expect(result.get('products[1][name]')).toBe('JavaScript SDK');
-      expect(result.get('products[2][variants][0][name]')).toBe('Something');
     });
   });
 });


### PR DESCRIPTION
multipart/form-data requests are not supported in PUT requests with PHP, so we must use application/json instead. Axios will use this by default when you pass it an object as the payload.

Fixes https://github.com/chec/commerce.js/issues/36