### PR TITLE
The cart object is now returned when refreshing

### DIFF
--- a/src/features/cart.js
+++ b/src/features/cart.js
@@ -92,7 +92,7 @@ class Cart {
 
   retrieve() {
     return this.request().then(cart => {
-      this.cartId = cart && cart.id ? cart.id : null;
+      this.cartId = (cart && cart.id) || null;
       return cart;
     });
   }

--- a/src/features/cart.js
+++ b/src/features/cart.js
@@ -10,7 +10,7 @@ class Cart {
   }
 
   /**
-   * Request a new cart ID. This method persists the new ID to the cart and local storage
+   * Request a new cart. This method persists the new cart ID to local storage
    *
    * @returns {Promise<object>} A promise that resolves to the new cart
    */

--- a/src/features/cart.js
+++ b/src/features/cart.js
@@ -6,18 +6,20 @@ class Cart {
    */
   constructor(commerce) {
     this.commerce = commerce;
-    this.cart = null;
+    this.cartId = null;
   }
 
   /**
    * Request a new cart ID. This method persists the new ID to the cart and local storage
+   *
+   * @returns {Promise<object>} A promise that resolves to the new cart
    */
   refresh() {
     return this.commerce.request('carts').then(cart => {
       const { id } = cart;
       this.commerce.storage.set('commercejs_cart_id', id, 30);
-      this.cart = cart;
-      return id;
+      this.cartId = id;
+      return cart;
     });
   }
 
@@ -27,8 +29,8 @@ class Cart {
    * @returns {string|null}
    */
   id() {
-    if (this.cart !== null && this.cart.id !== null) {
-      return this.cart.id;
+    if (this.cartId !== null) {
+      return this.cartId;
     }
 
     const storedCartId = this.commerce.storage.get('commercejs_cart_id');
@@ -90,7 +92,7 @@ class Cart {
 
   retrieve() {
     return this.request().then(cart => {
-      this.cart = cart;
+      this.cartId = cart && cart.id ? cart.id : null;
       return cart;
     });
   }

--- a/src/features/tests/cart-test.js
+++ b/src/features/tests/cart-test.js
@@ -154,13 +154,14 @@ describe('Cart', () => {
   describe('refresh', () => {
     it('sets the card ID and fires a ready event', async () => {
       const cart = new Cart(mockCommerce);
-      await cart.refresh();
+      const newCart = await cart.refresh();
 
       expect(storageSetMock).toHaveBeenCalledWith(
         'commercejs_cart_id',
         '12345',
         30,
       );
+      expect(newCart).toHaveProperty('id');
     });
   });
 


### PR DESCRIPTION
This also cleans up the local state stored in the Cart handler so we only store the cart ID. We don't want reliance on the state of the handler

Fixes #31