### PR TITLE
Fix syntax and config for iife (browser) rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ export default [
     output: {
       file: "./lib/commerce.js",
       format: "iife",
-      name: "bundle"
+      name: "Commerce"
     },
     plugins: [
       rollupCommonJs({

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 import Commerce from './commerce';
 
-module.exports = Commerce;
+export default Commerce;


### PR DESCRIPTION
Currently it's outputting `module.exports = Commerce` which causes a console error, and it's also defining the module as `bundle` and not `Commerce`.