### PR TITLE
Add checkout.registerStripePaymentIntent for SCA support

### DIFF
--- a/src/features/checkout.js
+++ b/src/features/checkout.js
@@ -275,6 +275,19 @@ class Checkout {
       data,
     );
   }
+
+  /**
+   * Registers a new Stripe Payment Intent, and returns that Intent's secret.
+   *
+   * @param {string} token
+   * @returns {Promise}
+   */
+  registerStripePaymentIntent(token) {
+    return this.commerce.request(
+      `checkouts/${token}/helper/registerStripePaymentIntent`,
+      'post',
+    );
+  }
 }
 
 export default Checkout;


### PR DESCRIPTION
This adds a Commerce.js accessor for registering a Stripe Payment Intent against the current checkout token. This should be done at some stage before processing an order. It returns a [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret), which should then be passed to Chec as part of your `checkouts.capture` payload under the `payment[card][intent]` key.