### PR TITLE
Fix incorrect "type" parameter in checkout.generateTokenFrom()

### DIFF
--- a/src/features/checkout.js
+++ b/src/features/checkout.js
@@ -41,7 +41,7 @@ class Checkout {
       throw new Error(`Cannot generate a token with unknown "${type}" type`);
     }
 
-    return this.generateToken(identifier, { identifier_type: type });
+    return this.generateToken(identifier, { type });
   }
 
   /**

--- a/src/features/tests/checkout-test.js
+++ b/src/features/tests/checkout-test.js
@@ -67,7 +67,7 @@ describe('Checkout', () => {
       const returnValue = checkout.generateTokenFrom('cart', 'foo');
 
       expect(requestMock).toHaveBeenLastCalledWith('checkouts/foo', 'get', {
-        identifier_type: 'cart',
+        type: 'cart',
       });
       const result = await returnValue;
       expect(result).toBe('return');


### PR DESCRIPTION
The API docs are incorrect, the parameter should be "type". Currently this results in a 402 error.