### PR TITLE
Add default value for data param in products.retrieve()

### DIFF
--- a/src/features/products.js
+++ b/src/features/products.js
@@ -25,7 +25,7 @@ class Products {
    * @param {object} data
    * @return {Promise}
    */
-  retrieve(permalink, data) {
+  retrieve(permalink, data = {}) {
     return this.commerce.request(`products/${permalink}`, 'get', data);
   }
 }

--- a/src/features/products.js
+++ b/src/features/products.js
@@ -21,12 +21,12 @@ class Products {
   /**
    * Get a specific product for the current merchant
    *
-   * @param {string} permalink
+   * @param {string} id
    * @param {object} data
    * @return {Promise}
    */
-  retrieve(permalink, data = {}) {
-    return this.commerce.request(`products/${permalink}`, 'get', data);
+  retrieve(id, data = {}) {
+    return this.commerce.request(`products/${id}`, 'get', data);
   }
 }
 


### PR DESCRIPTION
Also updates `permalink` to `id` in the variable name, since the default "type" for the identifier is "id" rather than "permalink"