### PR TITLE
Revert "Add checkout.registerStripePaymentIntent for SCA support"

### DIFF
--- a/src/features/checkout.js
+++ b/src/features/checkout.js
@@ -275,19 +275,6 @@ class Checkout {
       data,
     );
   }
-
-  /**
-   * Registers a new Stripe Payment Intent, and returns that Intent's secret.
-   *
-   * @param {string} token
-   * @returns {Promise}
-   */
-  registerStripePaymentIntent(token) {
-    return this.commerce.request(
-      `checkouts/${token}/helper/registerStripePaymentIntent`,
-      'post',
-    );
-  }
 }
 
 export default Checkout;


### PR DESCRIPTION
We are changing the way SCA payment flows work with Stripe. There is unfortunately no backwards compatibility for this method which has existed since Commerce.js 2.1.0, so I'm removing it.

This reverts commit b6cfda3a10551832e24b3dd394b2407072a2296a.