### PR TITLE
Remove inconsistent periods before methods

### DIFF
--- a/docs/02_Cart.md
+++ b/docs/02_Cart.md
@@ -114,7 +114,7 @@ curl -X POST \
 
 ## Update cart
 
-The `.update()` method uses `PUT v1/carts/{cart_id}/items/{line_item_id}` to update the quantity or variant for the line item ID in the cart.\
+The `update()` method uses `PUT v1/carts/{cart_id}/items/{line_item_id}` to update the quantity or variant for the line item ID in the cart.\
 \
 Example request using Commerce.js:
 
@@ -182,7 +182,7 @@ curl -X GET \
 
 ## Remove from cart
 
-The `.remove()` method uses `DELETE v1/carts/{cart_id}/items/{line_item_id}` to remove a specific line item from the cart.\
+The `remove()` method uses `DELETE v1/carts/{cart_id}/items/{line_item_id}` to remove a specific line item from the cart.\
 \
 Example request using Commerce.js:
 
@@ -215,7 +215,7 @@ curl -X DELETE \
 
 ## Delete cart
 
-The `.delete()` method uses `DELETE v1/carts/{cart_id}` to delete a cart entirely.\
+The `delete()` method uses `DELETE v1/carts/{cart_id}` to delete a cart entirely.\
 \
 Example request using Commerce.js:
 
@@ -248,7 +248,7 @@ curl -X DELETE \
 
 ## Empty cart
 
-The `.empty()` method uses `DELETE v1/carts/{cart_id}/items` to clear the contents of the current cart. This is different from the `.refresh()` method in that it empties the current cart but not create a new cart.\
+The `empty()` method uses `DELETE v1/carts/{cart_id}/items` to clear the contents of the current cart. This is different from the `.refresh()` method in that it empties the current cart but not create a new cart.\
 \
 Example request using Commerce.js:
 

--- a/docs/03_Checkout.md
+++ b/docs/03_Checkout.md
@@ -8,7 +8,7 @@ The checkout resource is used to navigate your customers through the transaction
 
 ## Generate token
 
-The `.generateToken()` method uses `GET v1/checkouts/{id}` to generate a [checkout token](/docs/sdk/concepts#checkout-tokens) which can be used to initiate the process of capturing an order from a cart. `generateTokenFrom()` gets a new checkout token from a specific identifier type. See below for the example request.\
+The `generateToken()` method uses `GET v1/checkouts/{id}` to generate a [checkout token](/docs/sdk/concepts#checkout-tokens) which can be used to initiate the process of capturing an order from a cart. `generateTokenFrom()` gets a new checkout token from a specific identifier type. See below for the example request.\
 \
 Example request using Commerce.js:
 
@@ -46,7 +46,7 @@ Upon a successful request, a checkout token object will be returned which contai
 
 ## Capture order
 
-The `.capture()` method uses `POST v1/checkouts/{checkout_token_id}` to capture an order and payment by providing the checkout token and necessary data for the order to be completed. The resolved promise returns an order object which can be used for receipt.\
+The `capture()` method uses `POST v1/checkouts/{checkout_token_id}` to capture an order and payment by providing the checkout token and necessary data for the order to be completed. The resolved promise returns an order object which can be used for receipt.\
 \
 Example request using Commerce.js:
 
@@ -123,7 +123,7 @@ Key-value multi-dimensional arrays/objects/hashes are used to immediately associ
 
 ## Get existing token
 
-The `.getToken()` method uses `GET v1/checkouts/tokens/{checkout_token_id}` to return an existing checkout token by it's ID. The output from this request will be the same as that of `.generateToken()`.\
+The `getToken()` method uses `GET v1/checkouts/tokens/{checkout_token_id}` to return an existing checkout token by it's ID. The output from this request will be the same as that of `.generateToken()`.\
 \
 Example request using Commerce.js:
 

--- a/docs/04_Concepts.md
+++ b/docs/04_Concepts.md
@@ -132,7 +132,7 @@ If you have EU VAT MOSS enabled for your account, you can use the helper functio
 
 <div class="highlight highlight--warn">
     <span>Important</span>
-    <p>If you're working with PayPal, you should sent both <code>tax[ip_address]</code> and <code>tax[country]</code> (by asking the customer to select their tax country from a dropdown). You can also set tax information for your checkout before you capture it using the <code>setTaxZone()</code></p>.
+    <p>If you're working with PayPal, you should sent both <code>tax[ip_address]</code> and <code>tax[country]</code> (by asking the customer to select their tax country from a dropdown). You can also set tax information for your checkout before you capture it using the <code>setTaxZone()</code>.</p>
 </div>
 
 ---


### PR DESCRIPTION
- removed inconsistent periods in methods in SDK
- moved period inline in an alert box in the concepts page