### PR TITLE
Add missing links and content

### DIFF
--- a/docs/03_Checkout.md
+++ b/docs/03_Checkout.md
@@ -2,24 +2,20 @@
 title: "Checkout"
 ---
 
-The checkout resource is used to navigate your customers through the transaction
-and shipping stage of a purchasing flow. A checkout captures data sent from the
-cart along with the item information, line item IDs, any shipping or billing
-information as well as tax and shipping rates. The checkout resource is a
-verbose endpoint that comes with additional helpers eg. [Checkout
-helpers](#checkout-helpers) and [Services](#services) to fully manage your
-customer's purchasing experience. See [here](/docs/sdk/concepts#checkout-tokens)
-for more high-level concepts on the Checkout resource.
+The checkout resource is used to navigate your customers through the transaction and shipping stage of a purchasing
+flow. A checkout captures data sent from the cart along with the item information, line item IDs, any shipping or
+billing information as well as tax and shipping rates. The checkout resource is a verbose endpoint that comes with
+additional helpers eg. [Checkout helpers](#checkout-helpers) and [Services](#services) to fully manage your customer's
+purchasing experience. See [here](/docs/sdk/concepts#checkout-tokens) for more high-level concepts on the Checkout
+resource.
 
 ---
 
 ## Generate token
 
-The `generateToken()` method uses `GET v1/checkouts/{id}` to generate a
-[checkout token](/docs/sdk/concepts#checkout-tokens) which can be used to
-initiate the process of capturing an order from a cart. `generateTokenFrom()`
-gets a new checkout token from a specific identifier type. See below for the
-example request.\
+The `generateToken()` method uses `GET v1/checkouts/{id}` to generate a [checkout
+token](/docs/sdk/concepts#checkout-tokens) which can be used to initiate the process of capturing an order from a cart.
+`generateTokenFrom()` gets a new checkout token from a specific identifier type. See below for the example request.\
 \
 Example request using Commerce.js:
 
@@ -40,8 +36,8 @@ commerce.checkout.generateTokenFrom('permalink', 'white-shirt')
 | -------------------- | ----------- |
 | `generateToken(identifier, data)` | Gets a new checkout token |
 
-Upon a successful request, a checkout token object will be returned which
-contains everything you need to create your checkout page.
+Upon a successful request, a checkout token object will be returned which contains everything you need to create your
+checkout page.
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -58,10 +54,9 @@ contains everything you need to create your checkout page.
 
 ## Capture order
 
-The `capture()` method uses `POST v1/checkouts/{checkout_token_id}` to capture
-an order and payment by providing the checkout token and necessary data for the
-order to be completed. The resolved promise returns an order object which can be
-used for receipt.\
+The `capture()` method uses `POST v1/checkouts/{checkout_token_id}` to capture an order and payment by providing the
+checkout token and necessary data for the order to be completed. The resolved promise returns an order object which can
+be used for receipt.\
 \
 Example request using Commerce.js:
 
@@ -117,20 +112,17 @@ commerce.checkout.capture({
 | -------------------- | ----------- |
 | `capture(token, data)`  | Capture a checkout by its token ID  |
 
-In response to a successful checkout capture, you'll get all the information for
-the order you need to show a confirmation page to your customer, including the
-`id` (the order ID), the `customer_reference` (customer's order reference), and
-much more. Note that you may want to store the response in local state since
-fetching the data again would require a secret key.\
+In response to a successful checkout capture, you'll get all the information for the order you need to show a
+confirmation page to your customer, including the `id` (the order ID), the `customer_reference` (customer's order
+reference), and much more. Note that you may want to store the response in local state since fetching the data again
+would require a secret key.\
 \
-Key-value multi-dimensional arrays/objects/hashes are used to immediately
-associate values with their parent(s) ID when submitting data. For example with
-line items, the key would be the `line_item_id` and the related values would be
-nested under that key.
+Key-value multi-dimensional arrays/objects/hashes are used to immediately associate values with their parent(s) ID when
+submitting data. For example with line items, the key would be the `line_item_id` and the related values would be nested
+under that key.
 
 * Line item's quantity: `line_items[{line_item_id}][quantity]`
-* Line item's variant and selected option:
-  `line_items[{line_item_id}][variants][{variant_id}] = {option_id}`
+* Line item's variant and selected option: `line_items[{line_item_id}][variants][{variant_id}] = {option_id}`
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -146,9 +138,8 @@ nested under that key.
 
 ## Get existing token
 
-The `getToken()` method uses `GET v1/checkouts/tokens/{checkout_token_id}` to
-return an existing checkout token by it's ID. The output from this request will
-be the same as that of `.generateToken()`.\
+The `getToken()` method uses `GET v1/checkouts/tokens/{checkout_token_id}` to return an existing checkout token by it's
+ID. The output from this request will be the same as that of `.generateToken()`.\
 \
 Example request using Commerce.js:
 
@@ -174,20 +165,16 @@ commerce.checkout.getToken('chkt_L5z3kmQpdpkGlA').then((token) => console.log(to
 
 # Checkout helpers
 
-[Checkout helper](/docs/sdk/concepts#checkout-helpers) functions are provided to
-help create custom checkout flows and handle all common commerce logic that
-would otherwise be complex. Every time a checkout helper endpoint is called, an
-object called the [live object](/docs/sdk/concepts#the-live-object) will be
-updated and the returned data is then typically used to update the checkout UI.
-All checkout helpers that affect price (e.g. check quantity, check variant,
+[Checkout helper](/docs/sdk/concepts#checkout-helpers) functions are provided to help create custom checkout flows and
+handle all common commerce logic that would otherwise be complex. Every time a checkout helper endpoint is called, an
+object called the [live object](/docs/sdk/concepts#the-live-object) will be updated and the returned data is then
+typically used to update the checkout UI. All checkout helpers that affect price (e.g. check quantity, check variant,
 check discount etc) will return the live object.
 
 ## Get the live object
 
-The live object is a living object which udpates to show the live tax rates,
-prices, and totals for a checkout token. The `getLive()` method uses `GET
-v1/checkouts/{checkout_token_id}/live` to return the current checkout live
-object.\
+The live object is a living object which udpates to show the live tax rates, prices, and totals for a checkout token.
+The `getLive()` method uses `GET v1/checkouts/{checkout_token_id}/live` to return the current checkout live object.\
 \
 Example request using Commerce.js:
 
@@ -213,12 +200,10 @@ Commerce.checkout.getLive('chkt_L5z3kmQpdpkGlA').then((response) => console.log(
 
 ## Check "Pay What You Want"
 
-If you have enabled "Pay What You Want" pricing, your customers are able to
-choose the amount they pay. The `checkPayWhatYouWant()` method uses `GET
-v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate and saves
-the desired "Pay What You Want" amount for the provided checkout token, if
-enabled. If the amount is too low, an invalid response will be returned with the
-minimum amount required.\
+If you have enabled "Pay What You Want" pricing, your customers are able to choose the amount they pay. The
+`checkPayWhatYouWant()` method uses `GET v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate and saves
+the desired "Pay What You Want" amount for the provided checkout token, if enabled. If the amount is too low, an invalid
+response will be returned with the minimum amount required.\
 \
 Example request using Commerce.js:
 
@@ -246,10 +231,8 @@ commerce.checkout.checkPayWhatYouWant('chkt_L5z3kmQpdpkGlA', {
 
 ## Check discount code
 
-The `checkDiscount()` method uses `GET
-v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate a discount
-code for the provided checkout token, and applies it to the order if it is
-valid.\
+The `checkDiscount()` method uses `GET v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate a discount
+code for the provided checkout token, and applies it to the order if it is valid.\
 \
 Example request using Commerce.js:
 
@@ -277,9 +260,8 @@ commerce.checkout.checkPayWhatYouWant('chkt_L5z3kmQpdpkGlA', {
 
 ## Check shipping method
 
-The `checkShippingOption()` method uses `GET
-v1/checkouts/{checkout_token_id}/check/shipping` to validate a shipping method
-for the provided checkout token, and applies it to the order.\
+The `checkShippingOption()` method uses `GET v1/checkouts/{checkout_token_id}/check/shipping` to validate a shipping
+method for the provided checkout token, and applies it to the order.\
 \
 Example request using Commerce.js:
 
@@ -310,10 +292,9 @@ commerce.checkout.checkShippingOption('chkt_L5z3kmQpdpkGlA', {
 
 ## Set tax zone
 
-The `setTaxZone()` method uses `GET
-v1/checkouts/{checkout_token_id}/helper/set_tax_zone` to set the tax zone for
-the provided checkout token's order, either automatically from a provided IP
-address, or by the geographic data provided in the request arguments.\
+The `setTaxZone()` method uses `GET v1/checkouts/{checkout_token_id}/helper/set_tax_zone` to set the tax zone for the
+provided checkout token's order, either automatically from a provided IP address, or by the geographic data provided in
+the request arguments.\
 \
 Example request using Commerce.js:
 
@@ -341,8 +322,7 @@ commerce.checkout.setTaxZone('chkt_L5z3kmQpdpkGlA', {
 
 ### Checkout SDK reference
 
-Refer to the full list of all the available checkout methods
-[here](/docs/sdk/full-sdk-reference#checkout).
+Refer to the full list of all the available checkout methods [here](/docs/sdk/full-sdk-reference#checkout).
 
 ---
 
@@ -352,10 +332,9 @@ The **Services** endpoint are additional checkout helpers service methods.
 
 ## List all countries
 
-The `localeListCountries()` method uses `GET v1/services/locale/countries`to
-return a list of all countries registered in the platform. See [List available
-shipping countries](#list-available-shipping-countries) for an equivalent list
-of countries that can be shipped to your account.\
+The `localeListCountries()` method uses `GET v1/services/locale/countries`to return a list of all countries registered
+in the platform. See [List available shipping countries](#list-available-shipping-countries) for an equivalent list of
+countries that can be shipped to your account.\
 \
 Example request using Commerce.js:
 
@@ -380,11 +359,9 @@ commerce.services.localeListCountries().then((response) => console.log(response)
 
 ## List all subdivisions for a country
 
-The `localeListSubdivisions()` method uses `GET
-v1/services/locale/{country_code}/subdivisions` to return a list of all
-subdivisions (states, provinces, or regions) for that country, given a valid
-country code is provided. See [List available shipping subdivisions for
-country](#list-available-shipping-subdivisions)" for an equivalent list of
+The `localeListSubdivisions()` method uses `GET v1/services/locale/{country_code}/subdivisions` to return a list of all
+subdivisions (states, provinces, or regions) for that country, given a valid country code is provided. See [List
+available shipping subdivisions for country](#list-available-shipping-subdivisions)" for an equivalent list of
 subdivisions that can be shipped to for your account.\
 \
 Example request using Commerce.js:
@@ -410,9 +387,8 @@ commerce.services.localeListSubdivisions('US').then((response) => console.log(re
 
 ## List available shipping countries
 
-The `localeListShippingCountries()` method at `GET
-v1/services/locale/{country_code}/subdivisions` returns only the countries which
-can be shipped to the current checkout.\
+The `localeListShippingCountries()` method at `GET v1/services/locale/{country_code}/subdivisions` returns only the
+countries which can be shipped to the current checkout.\
 \
 Example request using Commerce.js:
 
@@ -434,9 +410,8 @@ Commerce.services.localeListShippingCountries('chkt_L5z3kmQpdpkGlA').then((respo
 ## List available shipping subdivisions
 
 The `localeListShippingSubdivisions()` method at `GET
-v1/services/locale/{checkout_token_id}/countries/{country_code}/subdivisions`
-returns only the subdivisions (states, provinces, or regions) in a country which
-can be shipped to for the current checkout.\
+v1/services/locale/{checkout_token_id}/countries/{country_code}/subdivisions` returns only the subdivisions (states,
+provinces, or regions) in a country which can be shipped to for the current checkout.\
 \
 Example request using Commerce.js:
 
@@ -457,7 +432,6 @@ Commerce.services.localeListShippingSubdivisions('chkt_L5z3kmQpdpkGlA', 'US').th
 
 ### Services SDK reference
 
-Refer to the full list of all the available services methods
-[here](/docs/sdk/full-sdk-reference#services).
+Refer to the full list of all the available services methods [here](/docs/sdk/full-sdk-reference#services).
 
 ---

--- a/docs/03_Checkout.md
+++ b/docs/03_Checkout.md
@@ -2,13 +2,24 @@
 title: "Checkout"
 ---
 
-The checkout resource is used to navigate your customers through the transaction and shipping stage of a purchasing flow. A checkout captures data sent from the cart along with the item information, line item IDs, any shipping or billing information as well as tax and shipping rates. The checkout resource is a verbose endpoint that comes with additional helpers eg. [Checkout helpers](#checkout-helpers) and [Services](#services) to fully manage your customer's purchasing experience. See [here](/docs/sdk/concepts#checkout-tokens) for more high-level concepts on the Checkout resource.
+The checkout resource is used to navigate your customers through the transaction
+and shipping stage of a purchasing flow. A checkout captures data sent from the
+cart along with the item information, line item IDs, any shipping or billing
+information as well as tax and shipping rates. The checkout resource is a
+verbose endpoint that comes with additional helpers eg. [Checkout
+helpers](#checkout-helpers) and [Services](#services) to fully manage your
+customer's purchasing experience. See [here](/docs/sdk/concepts#checkout-tokens)
+for more high-level concepts on the Checkout resource.
 
 ---
 
 ## Generate token
 
-The `generateToken()` method uses `GET v1/checkouts/{id}` to generate a [checkout token](/docs/sdk/concepts#checkout-tokens) which can be used to initiate the process of capturing an order from a cart. `generateTokenFrom()` gets a new checkout token from a specific identifier type. See below for the example request.\
+The `generateToken()` method uses `GET v1/checkouts/{id}` to generate a
+[checkout token](/docs/sdk/concepts#checkout-tokens) which can be used to
+initiate the process of capturing an order from a cart. `generateTokenFrom()`
+gets a new checkout token from a specific identifier type. See below for the
+example request.\
 \
 Example request using Commerce.js:
 
@@ -29,7 +40,8 @@ commerce.checkout.generateTokenFrom('permalink', 'white-shirt')
 | -------------------- | ----------- |
 | `generateToken(identifier, data)` | Gets a new checkout token |
 
-Upon a successful request, a checkout token object will be returned which contains everything you need to create your checkout page.
+Upon a successful request, a checkout token object will be returned which
+contains everything you need to create your checkout page.
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -46,7 +58,10 @@ Upon a successful request, a checkout token object will be returned which contai
 
 ## Capture order
 
-The `capture()` method uses `POST v1/checkouts/{checkout_token_id}` to capture an order and payment by providing the checkout token and necessary data for the order to be completed. The resolved promise returns an order object which can be used for receipt.\
+The `capture()` method uses `POST v1/checkouts/{checkout_token_id}` to capture
+an order and payment by providing the checkout token and necessary data for the
+order to be completed. The resolved promise returns an order object which can be
+used for receipt.\
 \
 Example request using Commerce.js:
 
@@ -102,12 +117,20 @@ commerce.checkout.capture({
 | -------------------- | ----------- |
 | `capture(token, data)`  | Capture a checkout by its token ID  |
 
-In response to a successful checkout capture, you'll get all the information for the order you need to show a confirmation page to your customer, including the `id` (the order ID), the `customer_reference` (customer's order reference), and much more. Note that you may want to store the response in local state since fetching the data again would require a secret key.\
+In response to a successful checkout capture, you'll get all the information for
+the order you need to show a confirmation page to your customer, including the
+`id` (the order ID), the `customer_reference` (customer's order reference), and
+much more. Note that you may want to store the response in local state since
+fetching the data again would require a secret key.\
 \
-Key-value multi-dimensional arrays/objects/hashes are used to immediately associate values with their parent(s) ID when submitting data. For example with line items, the key would be the `line_item_id` and the related values would be nested under that key.
+Key-value multi-dimensional arrays/objects/hashes are used to immediately
+associate values with their parent(s) ID when submitting data. For example with
+line items, the key would be the `line_item_id` and the related values would be
+nested under that key.
 
 * Line item's quantity: `line_items[{line_item_id}][quantity]`
-* Line item's variant and selected option: `line_items[{line_item_id}][variants][{variant_id}] = {option_id}`
+* Line item's variant and selected option:
+  `line_items[{line_item_id}][variants][{variant_id}] = {option_id}`
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -123,7 +146,9 @@ Key-value multi-dimensional arrays/objects/hashes are used to immediately associ
 
 ## Get existing token
 
-The `getToken()` method uses `GET v1/checkouts/tokens/{checkout_token_id}` to return an existing checkout token by it's ID. The output from this request will be the same as that of `.generateToken()`.\
+The `getToken()` method uses `GET v1/checkouts/tokens/{checkout_token_id}` to
+return an existing checkout token by it's ID. The output from this request will
+be the same as that of `.generateToken()`.\
 \
 Example request using Commerce.js:
 
@@ -149,11 +174,20 @@ commerce.checkout.getToken('chkt_L5z3kmQpdpkGlA').then((token) => console.log(to
 
 # Checkout helpers
 
-[Checkout helper](/docs/sdk/concepts#checkout-helpers) functions are provided to help create custom checkout flows and handle all common commerce logic that would otherwise be complex. Every time a checkout helper endpoint is called, an object called the [live object](/docs/sdk/concepts#the-live-object) will be updated and the returned data is then typically used to update the checkout UI. All checkout helpers that affect price (e.g. check quantity, check variant, check discount etc) will return the live object.
+[Checkout helper](/docs/sdk/concepts#checkout-helpers) functions are provided to
+help create custom checkout flows and handle all common commerce logic that
+would otherwise be complex. Every time a checkout helper endpoint is called, an
+object called the [live object](/docs/sdk/concepts#the-live-object) will be
+updated and the returned data is then typically used to update the checkout UI.
+All checkout helpers that affect price (e.g. check quantity, check variant,
+check discount etc) will return the live object.
 
 ## Get the live object
 
-The live object is a living object which udpates to show the live tax rates, prices, and totals for a checkout token. The `getLive()` method uses `GET v1/checkouts/{checkout_token_id}/live` to return the current checkout live object.\
+The live object is a living object which udpates to show the live tax rates,
+prices, and totals for a checkout token. The `getLive()` method uses `GET
+v1/checkouts/{checkout_token_id}/live` to return the current checkout live
+object.\
 \
 Example request using Commerce.js:
 
@@ -179,7 +213,12 @@ Commerce.checkout.getLive('chkt_L5z3kmQpdpkGlA').then((response) => console.log(
 
 ## Check "Pay What You Want"
 
-If you have enabled "Pay What You Want" pricing, your customers are able to choose the amount they pay. The `checkPayWhatYouWant()` method uses `GET v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate and saves the desired "Pay What You Want" amount for the provided checkout token, if enabled. If the amount is too low, an invalid response will be returned with the minimum amount required.\
+If you have enabled "Pay What You Want" pricing, your customers are able to
+choose the amount they pay. The `checkPayWhatYouWant()` method uses `GET
+v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate and saves
+the desired "Pay What You Want" amount for the provided checkout token, if
+enabled. If the amount is too low, an invalid response will be returned with the
+minimum amount required.\
 \
 Example request using Commerce.js:
 
@@ -207,7 +246,10 @@ commerce.checkout.checkPayWhatYouWant('chkt_L5z3kmQpdpkGlA', {
 
 ## Check discount code
 
-The `checkDiscount()` method uses `GET v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate a discount code for the provided checkout token, and applies it to the order if it is valid.\
+The `checkDiscount()` method uses `GET
+v1/checkouts/{checkout_token_id}/check/pay_what_you_want` to validate a discount
+code for the provided checkout token, and applies it to the order if it is
+valid.\
 \
 Example request using Commerce.js:
 
@@ -235,7 +277,9 @@ commerce.checkout.checkPayWhatYouWant('chkt_L5z3kmQpdpkGlA', {
 
 ## Check shipping method
 
-The `checkShippingOption()` method uses `GET v1/checkouts/{checkout_token_id}/check/shipping` to validate a shipping method for the provided checkout token, and applies it to the order.\
+The `checkShippingOption()` method uses `GET
+v1/checkouts/{checkout_token_id}/check/shipping` to validate a shipping method
+for the provided checkout token, and applies it to the order.\
 \
 Example request using Commerce.js:
 
@@ -266,7 +310,10 @@ commerce.checkout.checkShippingOption('chkt_L5z3kmQpdpkGlA', {
 
 ## Set tax zone
 
-The `setTaxZone()` method uses `GET v1/checkouts/{checkout_token_id}/helper/set_tax_zone` to set the tax zone for the provided checkout token's order, either automatically from a provided IP address, or by the geographic data provided in the request arguments.\
+The `setTaxZone()` method uses `GET
+v1/checkouts/{checkout_token_id}/helper/set_tax_zone` to set the tax zone for
+the provided checkout token's order, either automatically from a provided IP
+address, or by the geographic data provided in the request arguments.\
 \
 Example request using Commerce.js:
 
@@ -294,7 +341,8 @@ commerce.checkout.setTaxZone('chkt_L5z3kmQpdpkGlA', {
 
 ### Checkout SDK reference
 
-Refer to the full list of all the available checkout methods [here](/docs/sdk/full-sdk-reference#checkout).
+Refer to the full list of all the available checkout methods
+[here](/docs/sdk/full-sdk-reference#checkout).
 
 ---
 
@@ -304,7 +352,10 @@ The **Services** endpoint are additional checkout helpers service methods.
 
 ## List all countries
 
-The `localeListCountries()` method uses `GET v1/services/locale/countries`to return a list of all countries registered in the platform. See [List available shipping countries](#list-available-shipping-countries) for an equivalent list of countries that can be shipped to your account.\
+The `localeListCountries()` method uses `GET v1/services/locale/countries`to
+return a list of all countries registered in the platform. See [List available
+shipping countries](#list-available-shipping-countries) for an equivalent list
+of countries that can be shipped to your account.\
 \
 Example request using Commerce.js:
 
@@ -329,7 +380,12 @@ commerce.services.localeListCountries().then((response) => console.log(response)
 
 ## List all subdivisions for a country
 
-The `localeListSubdivisions()` method uses `GET v1/services/locale/{country_code}/subdivisions` to return a list of all subdivisions (states, provinces, or regions) for that country, given a valid country code is provided. See [List available shipping subdivions for country](#list-available-shipping-subdivisions)" for an equivalent list of subdivisions that can be shipped to for your account.\
+The `localeListSubdivisions()` method uses `GET
+v1/services/locale/{country_code}/subdivisions` to return a list of all
+subdivisions (states, provinces, or regions) for that country, given a valid
+country code is provided. See [List available shipping subdivisions for
+country](#list-available-shipping-subdivisions)" for an equivalent list of
+subdivisions that can be shipped to for your account.\
 \
 Example request using Commerce.js:
 
@@ -354,7 +410,9 @@ commerce.services.localeListSubdivisions('US').then((response) => console.log(re
 
 ## List available shipping countries
 
-The `localeListShippingCountries()` method at `GET v1/services/locale/{country_code}/subdivisions` returns only the countries which can be shipped to the current checkout.\
+The `localeListShippingCountries()` method at `GET
+v1/services/locale/{country_code}/subdivisions` returns only the countries which
+can be shipped to the current checkout.\
 \
 Example request using Commerce.js:
 
@@ -370,11 +428,36 @@ Commerce.services.localeListShippingCountries('chkt_L5z3kmQpdpkGlA').then((respo
 
 <div class="highlight highlight--note">
     <span>Note</span>
-    <p>Refer to the full response for the "List available shipping countries" request <a href="docs/api/?shell#list-available-shipping-countries">here</a>.</p>
+    <p>Refer to the full response for the "List available shipping countries" request <a href="/docs/api/?shell#list-available-shipping-countries">here</a>.</p>
+</div>
+
+## List available shipping subdivisions
+
+The `localeListShippingSubdivisions()` method at `GET
+v1/services/locale/{checkout_token_id}/countries/{country_code}/subdivisions`
+returns only the subdivisions (states, provinces, or regions) in a country which
+can be shipped to for the current checkout.\
+\
+Example request using Commerce.js:
+
+```js
+import Commerce from '@chec/commerce.js';
+
+Commerce.services.localeListShippingSubdivisions('chkt_L5z3kmQpdpkGlA', 'US').then((response) => console.log(response));
+```
+
+| Method | Description |
+| -------------------- | ----------- |
+| `localeListSubdivisions(countryCode)` | List all subdivisions/regions/states for a country |
+
+<div class="highlight highlight--note">
+    <span>Note</span>
+    <p>Refer to the full response for the "List available shipping countries" request <a href="/docs/api/?shell#list-available-shipping-countries">here</a>.</p>
 </div>
 
 ### Services SDK reference
 
-Refer to the full list of all the available services methods [here](/docs/sdk/full-sdk-reference#services).
+Refer to the full list of all the available services methods
+[here](/docs/sdk/full-sdk-reference#services).
 
 ---

--- a/docs/04_Concepts.md
+++ b/docs/04_Concepts.md
@@ -4,14 +4,23 @@ title: "Concepts"
 
 ## Authentication
 
-When you [create a Chec account](https://dashboard.chec.io/signup), two sets of API authentication keys are generated, a **public key** and a **secret key**. The public key is used with Commerce.js to access all core resource endpoints. You can manage your API keys from your dashboard under the developer section.
+When you [create a Chec account](https://dashboard.chec.io/signup), two sets of
+API authentication keys are generated, a **public key** and a **secret key**.
+The public key is used with Commerce.js to access all core resource endpoints.
+You can manage your API keys from your dashboard under the developer section.
 
 <div class="highlight highlight--note">
     <span>Note</span>
     <p>To obtain your API keys, navigate to the developer section from your Chec Dashboard (<a href="https://dashboard.chec.io/settings/developer">Settings > Developer</a>).</p>
 </div>
 
-While using Commerce.js, the Chec API is limited to [public key scoped]() requests. We developed Commerce.js to to work alongside future server-side SDKs. Commerce.js utilizes your public API key which is required to retrieve non-sensitive data such from [products](), [cart](), and [checkout]() endpoints. It can also be used to capture orders although you will be unable to access the order resource for security reasons.
+While using Commerce.js, the Chec API is limited to [public key
+scoped](#public-keys) requests. We developed Commerce.js to to work alongside
+future server-side SDKs. Commerce.js utilizes your public API key which is
+required to retrieve non-sensitive data such from
+[products](/docs/sdk/products), [cart](/docs/sdk/cart), and
+[checkout](/docs/sdk/checkout) endpoints. It can also be used to capture orders
+although you will be unable to access the order resource for security reasons.
 
 <div class="highlight highlight--warn">
     <span>Note</span>
@@ -22,76 +31,107 @@ While using Commerce.js, the Chec API is limited to [public key scoped]() reques
 
 ## Scope
 
-Scope defines the varying levels of access a client has to a set of Chec API resources or operations performed on the resources. Scope provides a way to constrain and consider the granular access a client might need. We define our scope using public and secret keys.
+Scope defines the varying levels of access a client has to a set of Chec API
+resources or operations performed on the resources. Scope provides a way to
+constrain and consider the granular access a client might need. We define our
+scope using public and secret keys.
 
 ### Public keys
 
-To be used with Commerce.js's JavaScript SDK & any client-side code. Public APIs are limited by scope for this reason. Authenticating with the public key, you will have read and write access to the below resources.
+To be used with Commerce.js's JavaScript SDK & any client-side code. Public APIs
+are limited by scope for this reason. Authenticating with the public key, you
+will have read and write access to the below resources.
 
 | Read | Write |
 | -------------------- | ----------- |
 | Products       | Carts  |
 | Carts               | Checkout   |
 | Checkout            | Checkout helpers  |
-| Checkout helpers    |
-| Spaces    |
-| Settings    |
-| Categories    |
-| Fulfillment    |
+| Checkout helpers    | | Spaces    | | Settings    | | Categories    | |
+Fulfillment    |
 
 #### Client side
 
-The public key is to be used with requests that don't require any sensitive actions or data to be retrieved. The Commerce.js SDK includes all client side endpoints, so you can use them quickly and easily in your client-facing projects. An example would be to list your products from the `product` endpoint.
+The public key is to be used with requests that don't require any sensitive
+actions or data to be retrieved. The Commerce.js SDK includes all client side
+endpoints, so you can use them quickly and easily in your client-facing
+projects. An example would be to list your products from the `product` endpoint.
 
 ### Secret keys
 
-To be used with server side code. These API keys have the power to access sensitive data such as receipts and order data. Authenticating with the secret key will give you read and write access to the below resources.
+To be used with server side code. These API keys have the power to access
+sensitive data such as receipts and order data. Authenticating with the secret
+key will give you read and write access to the below resources.
 
 | Read & write |  |
 | -------------------- | ----------- |
-| Products       |
-| Carts               |
-| Checkout            |
-| Checkout helpers    |
-| Spaces    |
-| Settings    |
-| Categories    |
-| Fulfillment    |
+| Products       | | Carts               | | Checkout            | | Checkout
+helpers    | | Spaces    | | Settings    | | Categories    | | Fulfillment    |
 
 #### Server side
 
-The secret key can be used with requests that require sensitive actions or data to be retrieved as well as all client side requests. You'll use your secret key for these requests. The Commerce.js SDK does not include any of these endpoints for security reasons, so you'll need to write custom backend logic for handling these. An example of a sensitive request would be to make a call to [refund an order](https://commercejs.com/docs/api/?shell#refund-an-order).
+The secret key can be used with requests that require sensitive actions or data
+to be retrieved as well as all client side requests. You'll use your secret key
+for these requests. The Commerce.js SDK does not include any of these endpoints
+for security reasons, so you'll need to write custom backend logic for handling
+these. An example of a sensitive request would be to make a call to [refund an
+order](/docs/api/?shell#refund-an-order).
 
 <div class="highlight highlight--warn">
     <span>Important</span>
     <p>The Commerce.js SDK does not include any of these endpoints for security reasons, so you'll need to write custom backend logic for handling these.</p>
 </div>
 
-When you register for a Chec account, you'll be assigned two sets of these keys: live and sandbox. We highly recommend using your sandbox key until you're ready to deploy your new project live. Orders created with sandbox keys can easily be cleared from the Chec Dashboard, and will automatically use the "Test Gateway" for payment processing.
+When you register for a Chec account, you'll be assigned two sets of these keys:
+live and sandbox. We highly recommend using your sandbox key until you're ready
+to deploy your new project live. Orders created with sandbox keys can easily be
+cleared from the Chec Dashboard, and will automatically use the "Test Gateway"
+for payment processing.
 
 ---
 
 ## Checkout tokens
 
-Checkout tokens need to be generated before you are able to **capture an order**. A [checkout token](https://commercejs.com/docs/api/?javascript--cjs#generate-token) contains everything you would need to implement a checkout process and a unqiue purchasing experience for your users. For example, the returned object will contain properties such as shipping options, discount codes available, or other fields that are needed to be collected.\
+Checkout tokens need to be generated before you are able to **capture an
+order**. A [checkout
+token](/docs/api/?javascript--cjs#generate-token) contains
+everything you would need to implement a checkout process and a unqiue
+purchasing experience for your users. For example, the returned object will
+contain properties such as shipping options, discount codes available, or other
+fields that are needed to be collected.\
 \
-To generate a checkout token, all you need to provide is the permalink or ID of the product, or the cart ID you'd like to generate a checkout for. See [here](https://commercejs.com/docs/api/#generate-token) for the required parameters.
+To generate a checkout token, all you need to provide is the permalink or ID of
+the product, or the cart ID you'd like to generate a checkout for. See
+[here](/docs/api/#generate-token) for the required
+parameters.
 
 ---
 
 ## Checkout helpers
 
-Commerce.js [checkout helper functions](https://commercejs.com/docs/api/?shell#checkout-helpers) are provided to help create custom checkout flows and handle all common commerce logic that would otherwise be complex. Below are some examples of various checkpoints during the checkout process:
+Commerce.js [checkout helper
+functions](/docs/api/?shell#checkout-helpers) are provided
+to help create custom checkout flows and handle all common commerce logic that
+would otherwise be complex. Below are some examples of various checkpoints
+during the checkout process:
 
 * Check if a requested variant, quantity, or shipping option is available
 * Check if an entered *"Pay What You Want"* amount or discount code is valid
-* Retrieve running totals for a checkout (i.e. subtotals, shipping totals, and grand totals) - [the live object](#the-live-object)
+* Retrieve running totals for a checkout (i.e. subtotals, shipping totals, and
+  grand totals) - [the live object](#the-live-object)
 * Generate client side validation rules
 * Get a full list of states/provinces for a country to populate a select field
 * Get the buyer's location from an IP address
-* Set a new tax zone for the checkout when the customer changes their shipping address
+* Set a new tax zone for the checkout when the customer changes their shipping
+  address
 
-All helper endpoints on the [Checkout](https://commercejs.com/docs/api/?shell#checkout) resource update the live object. E.g. If you select a variant that is available or a quantity that is available, the live object will be adjusted to reflect this. Most responses contain a [live object](#the-live-object) which gives you the live running totals and other information relevant to the current checkout session so you can update displayed totals (and more) straight away.
+All helper endpoints on the
+[Checkout](/docs/api/?shell#checkout) resource update the
+live object. E.g. If you select a variant that is available or a quantity that
+is available, the live object will be adjusted to reflect this. Most responses
+contain a [live object](#the-live-object) which gives you the live running
+totals and other information relevant to the current checkout session so you can
+update displayed totals (and more) straight away.
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -107,17 +147,32 @@ All helper endpoints on the [Checkout](https://commercejs.com/docs/api/?shell#ch
 
 ## The live object
 
-The [live object](https://commercejs.com/docs/api/?shell#get-the-live-object) is a living object which adjusts to show the live tax rates, prices, and totals for a checkout token. Every time a checkout helper endpoint is called, this object will be updated. The returned data can be used to display information back to the customer on the checkout. All checkout helpers that affect price (e.g. check quantity, check variant, check discount, etc) will return the live object in its payload.\
+The [live object](/docs/api/?shell#get-the-live-object) is
+a living object which adjusts to show the live tax rates, prices, and totals for
+a checkout token. Every time a checkout helper endpoint is called, this object
+will be updated. The returned data can be used to display information back to
+the customer on the checkout. All checkout helpers that affect price (e.g. check
+quantity, check variant, check discount, etc) will return the live object in its
+payload.\
 \
-We create the live object to help you (and us!) display up-to-date totals, tax prices, and other dynamic variables which change during the checkout process and need to displayed back to the customer. You should use the data in the live object to update the displayed totals on your checkout pages when the customer selects a new variant, enters a discount, or selects a different shipping option.\
+We create the live object to help you (and us!) display up-to-date totals, tax
+prices, and other dynamic variables which change during the checkout process and
+need to displayed back to the customer. You should use the data in the live
+object to update the displayed totals on your checkout pages when the customer
+selects a new variant, enters a discount, or selects a different shipping
+option.\
 \
-At Chec we do this on our own checkouts by feeding the live object returned from each helper function into a JavaScript function which then associates the data with the correct element.
+At Chec we do this on our own checkouts by feeding the live object returned from
+each helper function into a JavaScript function which then associates the data
+with the correct element.
 
 ---
 
 ## Tax support
 
-Tax support with Chec/Commerce.js is automatic. We calculate the tax based on the shipping address submitted. If you're not submitting an address for the customer, you can supply the tax region with these arguments:
+Tax support with Chec/Commerce.js is automatic. We calculate the tax based on
+the shipping address submitted. If you're not submitting an address for the
+customer, you can supply the tax region with these arguments:
 
 | Parameter | Status | Description |
 | -------------------- | ----------- | ----------- |
@@ -128,7 +183,9 @@ Tax support with Chec/Commerce.js is automatic. We calculate the tax based on th
 
 ### EU VAT MOSS
 
-If you have EU VAT MOSS enabled for your account, you can use the helper function "Get buyer's location from IP" (see the full API reference), and use this value to set `tax[ip_address]`.
+If you have EU VAT MOSS enabled for your account, you can use the helper
+function "Get buyer's location from IP" (see the full API reference), and use
+this value to set `tax[ip_address]`.
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -139,13 +196,17 @@ If you have EU VAT MOSS enabled for your account, you can use the helper functio
 
 ## Multiple price formats
 
-Every price attribute (subtotals, pay what you want minimums, tax totals, etc) returned from Chec will be an array with four formats:
+Every price attribute (subtotals, pay what you want minimums, tax totals, etc)
+returned from Chec will be an array with four formats:
 
 - `raw` - No formatting *e.g. 49 or 1234.56*
-- `formatted` - Formatted with no currency symbol or code *e.g. 49.00 or 1,234.56*
-- `formatted_with_symbol` - Formatted with its symbol only *e.g. $49.00 or £1,234.56*
-- `formatted_with_code` -  Formatted with its currency code only *e.g. 49.00 USD or 1,234.56 GBP*\
-\
+- `formatted` - Formatted with no currency symbol or code *e.g. 49.00 or
+  1,234.56*
+- `formatted_with_symbol` - Formatted with its symbol only *e.g. $49.00 or
+  £1,234.56*
+- `formatted_with_code` -  Formatted with its currency code only *e.g. 49.00 USD
+  or 1,234.56 GBP*\
+  \
 Example of a `price` endpoint response:
 
 ```json
@@ -163,7 +224,9 @@ Example of a `price` endpoint response:
 
 ## Verb conditionals
 
-We return all conditionals in the `conditionals` array in most objects. We also return conditionals with their verb as the array key name e.g. `is.cart_free` or `has.physical_delivery` or `collects.shipping_address`.\
+We return all conditionals in the `conditionals` array in most objects. We also
+return conditionals with their verb as the array key name e.g. `is.cart_free` or
+`has.physical_delivery` or `collects.shipping_address`.\
 \
 Example of a `conditionals` array:
 
@@ -198,6 +261,10 @@ Example of a `conditionals` array:
 }
 ```
 
-We created this `conditionals` property to hopefully provide more legibility and maintainability of your code. By nesting variables under their *"verb key"* your code reads better. E.g. `checkout.conditionals.is_cart_free` vs `checkout.is.cart_free`. This is particularly nicer to work with for developers who are primarily working with JavaScript.
+We created this `conditionals` property to hopefully provide more legibility and
+maintainability of your code. By nesting variables under their *"verb key"* your
+code reads better. E.g. `checkout.conditionals.is_cart_free` vs
+`checkout.is.cart_free`. This is particularly nicer to work with for developers
+who are primarily working with JavaScript.
 
 ---

--- a/docs/04_Concepts.md
+++ b/docs/04_Concepts.md
@@ -4,23 +4,20 @@ title: "Concepts"
 
 ## Authentication
 
-When you [create a Chec account](https://dashboard.chec.io/signup), two sets of
-API authentication keys are generated, a **public key** and a **secret key**.
-The public key is used with Commerce.js to access all core resource endpoints.
-You can manage your API keys from your dashboard under the developer section.
+When you [create a Chec account](https://dashboard.chec.io/signup), two sets of API authentication keys are generated, a
+**public key** and a **secret key**. The public key is used with Commerce.js to access all core resource endpoints. You
+can manage your API keys from your dashboard under the developer section.
 
 <div class="highlight highlight--note">
     <span>Note</span>
     <p>To obtain your API keys, navigate to the developer section from your Chec Dashboard (<a href="https://dashboard.chec.io/settings/developer">Settings > Developer</a>).</p>
 </div>
 
-While using Commerce.js, the Chec API is limited to [public key
-scoped](#public-keys) requests. We developed Commerce.js to to work alongside
-future server-side SDKs. Commerce.js utilizes your public API key which is
-required to retrieve non-sensitive data such from
-[products](/docs/sdk/products), [cart](/docs/sdk/cart), and
-[checkout](/docs/sdk/checkout) endpoints. It can also be used to capture orders
-although you will be unable to access the order resource for security reasons.
+While using Commerce.js, the Chec API is limited to [public key scoped](#public-keys) requests. We developed Commerce.js
+to to work alongside future server-side SDKs. Commerce.js utilizes your public API key which is required to retrieve
+non-sensitive data such from [products](/docs/sdk/products), [cart](/docs/sdk/cart), and [checkout](/docs/sdk/checkout)
+endpoints. It can also be used to capture orders although you will be unable to access the order resource for security
+reasons.
 
 <div class="highlight highlight--warn">
     <span>Note</span>
@@ -31,16 +28,14 @@ although you will be unable to access the order resource for security reasons.
 
 ## Scope
 
-Scope defines the varying levels of access a client has to a set of Chec API
-resources or operations performed on the resources. Scope provides a way to
-constrain and consider the granular access a client might need. We define our
-scope using public and secret keys.
+Scope defines the varying levels of access a client has to a set of Chec API resources or operations performed on the
+resources. Scope provides a way to constrain and consider the granular access a client might need. We define our scope
+using public and secret keys.
 
 ### Public keys
 
-To be used with Commerce.js's JavaScript SDK & any client-side code. Public APIs
-are limited by scope for this reason. Authenticating with the public key, you
-will have read and write access to the below resources.
+To be used with Commerce.js's JavaScript SDK & any client-side code. Public APIs are limited by scope for this reason.
+Authenticating with the public key, you will have read and write access to the below resources.
 
 | Read | Write |
 | -------------------- | ----------- |
@@ -52,16 +47,14 @@ Fulfillment    |
 
 #### Client side
 
-The public key is to be used with requests that don't require any sensitive
-actions or data to be retrieved. The Commerce.js SDK includes all client side
-endpoints, so you can use them quickly and easily in your client-facing
+The public key is to be used with requests that don't require any sensitive actions or data to be retrieved. The
+Commerce.js SDK includes all client side endpoints, so you can use them quickly and easily in your client-facing
 projects. An example would be to list your products from the `product` endpoint.
 
 ### Secret keys
 
-To be used with server side code. These API keys have the power to access
-sensitive data such as receipts and order data. Authenticating with the secret
-key will give you read and write access to the below resources.
+To be used with server side code. These API keys have the power to access sensitive data such as receipts and order
+data. Authenticating with the secret key will give you read and write access to the below resources.
 
 | Read & write |  |
 | -------------------- | ----------- |
@@ -70,68 +63,53 @@ helpers    | | Spaces    | | Settings    | | Categories    | | Fulfillment    |
 
 #### Server side
 
-The secret key can be used with requests that require sensitive actions or data
-to be retrieved as well as all client side requests. You'll use your secret key
-for these requests. The Commerce.js SDK does not include any of these endpoints
-for security reasons, so you'll need to write custom backend logic for handling
-these. An example of a sensitive request would be to make a call to [refund an
-order](/docs/api/?shell#refund-an-order).
+The secret key can be used with requests that require sensitive actions or data to be retrieved as well as all client
+side requests. You'll use your secret key for these requests. The Commerce.js SDK does not include any of these
+endpoints for security reasons, so you'll need to write custom backend logic for handling these. An example of a
+sensitive request would be to make a call to [refund an order](/docs/api/?shell#refund-an-order).
 
 <div class="highlight highlight--warn">
     <span>Important</span>
     <p>The Commerce.js SDK does not include any of these endpoints for security reasons, so you'll need to write custom backend logic for handling these.</p>
 </div>
 
-When you register for a Chec account, you'll be assigned two sets of these keys:
-live and sandbox. We highly recommend using your sandbox key until you're ready
-to deploy your new project live. Orders created with sandbox keys can easily be
-cleared from the Chec Dashboard, and will automatically use the "Test Gateway"
-for payment processing.
+When you register for a Chec account, you'll be assigned two sets of these keys: live and sandbox. We highly recommend
+using your sandbox key until you're ready to deploy your new project live. Orders created with sandbox keys can easily
+be cleared from the Chec Dashboard, and will automatically use the "Test Gateway" for payment processing.
 
 ---
 
 ## Checkout tokens
 
-Checkout tokens need to be generated before you are able to **capture an
-order**. A [checkout
-token](/docs/api/?javascript--cjs#generate-token) contains
-everything you would need to implement a checkout process and a unqiue
-purchasing experience for your users. For example, the returned object will
-contain properties such as shipping options, discount codes available, or other
-fields that are needed to be collected.\
+Checkout tokens need to be generated before you are able to **capture an order**. A [checkout
+token](/docs/api/?javascript--cjs#generate-token) contains everything you would need to implement a checkout process and
+a unqiue purchasing experience for your users. For example, the returned object will contain properties such as shipping
+options, discount codes available, or other fields that are needed to be collected.\
 \
-To generate a checkout token, all you need to provide is the permalink or ID of
-the product, or the cart ID you'd like to generate a checkout for. See
-[here](/docs/api/#generate-token) for the required
-parameters.
+To generate a checkout token, all you need to provide is the permalink or ID of the product, or the cart ID you'd like
+to generate a checkout for. See [here](/docs/api/#generate-token) for the required parameters.
 
 ---
 
 ## Checkout helpers
 
-Commerce.js [checkout helper
-functions](/docs/api/?shell#checkout-helpers) are provided
-to help create custom checkout flows and handle all common commerce logic that
-would otherwise be complex. Below are some examples of various checkpoints
-during the checkout process:
+Commerce.js [checkout helper functions](/docs/api/?shell#checkout-helpers) are provided to help create custom checkout
+flows and handle all common commerce logic that would otherwise be complex. Below are some examples of various
+checkpoints during the checkout process:
 
 * Check if a requested variant, quantity, or shipping option is available
 * Check if an entered *"Pay What You Want"* amount or discount code is valid
-* Retrieve running totals for a checkout (i.e. subtotals, shipping totals, and
-  grand totals) - [the live object](#the-live-object)
+* Retrieve running totals for a checkout (i.e. subtotals, shipping totals, and grand totals) - [the live
+  object](#the-live-object)
 * Generate client side validation rules
 * Get a full list of states/provinces for a country to populate a select field
 * Get the buyer's location from an IP address
-* Set a new tax zone for the checkout when the customer changes their shipping
-  address
+* Set a new tax zone for the checkout when the customer changes their shipping address
 
-All helper endpoints on the
-[Checkout](/docs/api/?shell#checkout) resource update the
-live object. E.g. If you select a variant that is available or a quantity that
-is available, the live object will be adjusted to reflect this. Most responses
-contain a [live object](#the-live-object) which gives you the live running
-totals and other information relevant to the current checkout session so you can
-update displayed totals (and more) straight away.
+All helper endpoints on the [Checkout](/docs/api/?shell#checkout) resource update the live object. E.g. If you select a
+variant that is available or a quantity that is available, the live object will be adjusted to reflect this. Most
+responses contain a [live object](#the-live-object) which gives you the live running totals and other information
+relevant to the current checkout session so you can update displayed totals (and more) straight away.
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -147,32 +125,25 @@ update displayed totals (and more) straight away.
 
 ## The live object
 
-The [live object](/docs/api/?shell#get-the-live-object) is
-a living object which adjusts to show the live tax rates, prices, and totals for
-a checkout token. Every time a checkout helper endpoint is called, this object
-will be updated. The returned data can be used to display information back to
-the customer on the checkout. All checkout helpers that affect price (e.g. check
-quantity, check variant, check discount, etc) will return the live object in its
-payload.\
+The [live object](/docs/api/?shell#get-the-live-object) is a living object which adjusts to show the live tax rates,
+prices, and totals for a checkout token. Every time a checkout helper endpoint is called, this object will be updated.
+The returned data can be used to display information back to the customer on the checkout. All checkout helpers that
+affect price (e.g. check quantity, check variant, check discount, etc) will return the live object in its payload.\
 \
-We create the live object to help you (and us!) display up-to-date totals, tax
-prices, and other dynamic variables which change during the checkout process and
-need to displayed back to the customer. You should use the data in the live
-object to update the displayed totals on your checkout pages when the customer
-selects a new variant, enters a discount, or selects a different shipping
-option.\
+We create the live object to help you (and us!) display up-to-date totals, tax prices, and other dynamic variables which
+change during the checkout process and need to displayed back to the customer. You should use the data in the live
+object to update the displayed totals on your checkout pages when the customer selects a new variant, enters a discount,
+or selects a different shipping option.\
 \
-At Chec we do this on our own checkouts by feeding the live object returned from
-each helper function into a JavaScript function which then associates the data
-with the correct element.
+At Chec we do this on our own checkouts by feeding the live object returned from each helper function into a JavaScript
+function which then associates the data with the correct element.
 
 ---
 
 ## Tax support
 
-Tax support with Chec/Commerce.js is automatic. We calculate the tax based on
-the shipping address submitted. If you're not submitting an address for the
-customer, you can supply the tax region with these arguments:
+Tax support with Chec/Commerce.js is automatic. We calculate the tax based on the shipping address submitted. If you're
+not submitting an address for the customer, you can supply the tax region with these arguments:
 
 | Parameter | Status | Description |
 | -------------------- | ----------- | ----------- |
@@ -183,9 +154,8 @@ customer, you can supply the tax region with these arguments:
 
 ### EU VAT MOSS
 
-If you have EU VAT MOSS enabled for your account, you can use the helper
-function "Get buyer's location from IP" (see the full API reference), and use
-this value to set `tax[ip_address]`.
+If you have EU VAT MOSS enabled for your account, you can use the helper function "Get buyer's location from IP" (see
+the full API reference), and use this value to set `tax[ip_address]`.
 
 <div class="highlight highlight--warn">
     <span>Important</span>
@@ -196,16 +166,13 @@ this value to set `tax[ip_address]`.
 
 ## Multiple price formats
 
-Every price attribute (subtotals, pay what you want minimums, tax totals, etc)
-returned from Chec will be an array with four formats:
+Every price attribute (subtotals, pay what you want minimums, tax totals, etc) returned from Chec will be an array with
+four formats:
 
 - `raw` - No formatting *e.g. 49 or 1234.56*
-- `formatted` - Formatted with no currency symbol or code *e.g. 49.00 or
-  1,234.56*
-- `formatted_with_symbol` - Formatted with its symbol only *e.g. $49.00 or
-  £1,234.56*
-- `formatted_with_code` -  Formatted with its currency code only *e.g. 49.00 USD
-  or 1,234.56 GBP*\
+- `formatted` - Formatted with no currency symbol or code *e.g. 49.00 or 1,234.56*
+- `formatted_with_symbol` - Formatted with its symbol only *e.g. $49.00 or£1,234.56*
+- `formatted_with_code` -  Formatted with its currency code only *e.g. 49.00 USD or 1,234.56 GBP*\
   \
 Example of a `price` endpoint response:
 
@@ -224,9 +191,8 @@ Example of a `price` endpoint response:
 
 ## Verb conditionals
 
-We return all conditionals in the `conditionals` array in most objects. We also
-return conditionals with their verb as the array key name e.g. `is.cart_free` or
-`has.physical_delivery` or `collects.shipping_address`.\
+We return all conditionals in the `conditionals` array in most objects. We also return conditionals with their verb as
+the array key name e.g. `is.cart_free` or `has.physical_delivery` or `collects.shipping_address`.\
 \
 Example of a `conditionals` array:
 
@@ -261,10 +227,9 @@ Example of a `conditionals` array:
 }
 ```
 
-We created this `conditionals` property to hopefully provide more legibility and
-maintainability of your code. By nesting variables under their *"verb key"* your
-code reads better. E.g. `checkout.conditionals.is_cart_free` vs
-`checkout.is.cart_free`. This is particularly nicer to work with for developers
-who are primarily working with JavaScript.
+We created this `conditionals` property to hopefully provide more legibility and maintainability of your code. By
+nesting variables under their *"verb key"* your code reads better. E.g. `checkout.conditionals.is_cart_free` vs
+`checkout.is.cart_free`. This is particularly nicer to work with for developers who are primarily working with
+JavaScript.
 
 ---


### PR DESCRIPTION
This PR is in conjunction with the relative links bug I'm about to put up (spotted missing links, content while testing SDK docs)
- Add missing links
- Add missing forward slashes in links
- Add missing checkout helper method "list shipping subdivisions"

Disclaimer: I've tried to use a hard length wrapper extension in vscode and a built-in VSCode one, but it looks like its not working... FYI sorry Robbie! While editing, my markdown and comments are actually wrapping at 80, not sure why its not coming through in this pr