### PR TITLE
Add specific implicit params to add to cart method

### DIFF
--- a/docs/02_Cart.md
+++ b/docs/02_Cart.md
@@ -104,7 +104,7 @@ curl -X POST \
 
 | Method | Description |
 | -------------------- | ----------- |
-| `add(data)`  | Add an item to the cart |
+| `add(productId, quantity)`  | Add an item to the cart |
 
 <div class="highlight highlight--info">
     <span>Tip</span>

--- a/docs/05_Full-SDK-Reference.md
+++ b/docs/05_Full-SDK-Reference.md
@@ -39,7 +39,7 @@ object instance.
 | -------------------- | ----------- |
 | `id()`       | Get the current cart ID, generating a new one if necessary |
 | `refresh()`  | Request a new cart ID |
-| `add(data)`  | Add an item to the cart |
+| `add(productId, quantity)`  | Add an item to the cart |
 | `retrieve()` | Get the cart object, including contents |
 | `contents()` | Get the contents of the cart |
 | `update(lineItemId, data)` | Update an existing item in the cart |


### PR DESCRIPTION
Jamie noted that add to cart method should specify the params, `data` can be broad and misleading