### PR TITLE
Remove PayPal listener helpers, they are no longer operational

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ The `cart.add()` method now separates its arguments:
 
 ## Contributing
 
+### Compilation
+
+The lib files are automatically compiled by our continuous integration pipeline. You only need to commit changes
+to the `src` files.
+
 ### Running the tests
 
 You can run the unit tests for this library from your command line using `npm run test`, or `npm run test:watch`

--- a/docs/03_Checkout.md
+++ b/docs/03_Checkout.md
@@ -129,7 +129,7 @@ under that key.
 
 <div class="highlight highlight--warn">
     <span>Important</span>
-    <p>When using PayPal, the response returned will contain the information required for you to redirect your customer to PayPal in order to complete their transaction. Read more <a href="/docs/sdk/concepts#tax-support">here</a> for required parameters to send when using PayPal.</p>
+    <p>When using PayPal, the response returned will contain the information required for you to redirect your customer to PayPal in order to complete their transaction. Read more <a href="/docs/sdk/concepts#tax-support">here</a> for required parameters to send when using PayPal, or <a href="https://developer.paypal.com/docs/archive/checkout/how-to/customize-flow/"> see here</a> for the PayPal documentation.</p>
 </div>
 
 <div class="highlight highlight--note">

--- a/docs/05_Full-SDK-Reference.md
+++ b/docs/05_Full-SDK-Reference.md
@@ -65,8 +65,6 @@ object instance.
 | `setTaxZone(identifier, data)`  | Sets the geographic zone for tax calculation  |
 | `checkDiscount(token, data)`  | Checks whether a discount code is valid  |
 | `checkGiftcard(token, data)`  | Checks whether a gift card (code) is valid  |
-| `checkPaypalStatus(token)`  | Checks the status of a PayPal payment  |
-| `checkPaypalOrderCaptured(token)`  | Checks whether the status of a PayPal payment is captured  |
 | `checkPayWhatYouWant(token, data)`  | Checks whether a checkout has "pay what you want" enabled  |
 | `checkShippingOption(token, data)`  | Checks whether a shipping method is valid  |
 | `checkVariant(token, lineItemId, data)`  | Checks whether the specified line item ID is still valid/available  |

--- a/src/features/checkout.js
+++ b/src/features/checkout.js
@@ -63,26 +63,6 @@ class Checkout {
   }
 
   /**
-   * Checks the status of a PayPal payment for the provided checkout token
-   *
-   * @param {string} token
-   * @return {Promise}
-   */
-  checkPaypalStatus(token) {
-    return this.commerce.request(`checkouts/${token}/check/paypal/payment`);
-  }
-
-  /**
-   * Checks whether the status a PayPal payment for the provided checkout token is captured
-   *
-   * @param {string} token
-   * @return {Promise}
-   */
-  checkPaypalOrderCaptured(token) {
-    return this.commerce.request(`checkouts/${token}/check/paypal/captured`);
-  }
-
-  /**
    * Gets the receipt for the provided checkout token
    *
    * @param {string} token

--- a/src/features/tests/checkout-test.js
+++ b/src/features/tests/checkout-test.js
@@ -93,36 +93,6 @@ describe('Checkout', () => {
     });
   });
 
-  describe('checkPaypalStatus', () => {
-    it('proxies the request method', async () => {
-      const checkout = new Checkout(mockCommerce);
-      const returnValue = checkout.checkPaypalStatus(
-        'abc123',
-        mockCallback,
-        mockErrorCallback,
-      );
-
-      expect(requestMock).toHaveBeenLastCalledWith(
-        'checkouts/abc123/check/paypal/payment',
-      );
-      const result = await returnValue;
-      expect(result).toBe('return');
-    });
-  });
-
-  describe('checkPaypalOrderCaptured', () => {
-    it('proxies the request method', async () => {
-      const checkout = new Checkout(mockCommerce);
-      const returnValue = checkout.checkPaypalOrderCaptured('abc123');
-
-      expect(requestMock).toHaveBeenLastCalledWith(
-        'checkouts/abc123/check/paypal/captured',
-      );
-      const result = await returnValue;
-      expect(result).toBe('return');
-    });
-  });
-
   describe('receipt', () => {
     it('proxies the request method', async () => {
       const checkout = new Checkout(mockCommerce);


### PR DESCRIPTION
Internally we discussed making these methods throw an error instead of removing them, since it is technically a semver violation, but either way the change is not backwards compatible. The API methods are no longer operational, and will not be re-implemented, so there is no path for backwards compatibility.