### PR TITLE
Fix typo in 05_Full-SDK-Reference.md

### DIFF
--- a/docs/05_Full-SDK-Reference.md
+++ b/docs/05_Full-SDK-Reference.md
@@ -6,7 +6,7 @@ category: Full SDK reference
 ---
 
 **Commerce.js** is a JavaScript SDK built on top of the **Chec Platform** to allow for easy interfacing with the **Chec
-API**. The Commerce.js SDK provides all the features you need to build a custom commerce web experience that work on any
+API**. The Commerce.js SDK provides all the features you need to build a custom commerce web experience that works on any
 modern domain. The SDK comes packed with helper functions that are essential to manage complexity in the commerce logic
 of an application. Here you will find the full Commerce.js SDK reference. All features are accessible from your Commerce
 object instance.


### PR DESCRIPTION
Fixes a (possible) small typo.

Another option to what's on the pr could be to turn "a custom commerce web experience" to "custom commerce web experiences" and leave "work" as it is.


