### PR TITLE
docs(products): add product params

### DIFF
--- a/docs/05_Full-SDK-Reference.md
+++ b/docs/05_Full-SDK-Reference.md
@@ -19,7 +19,7 @@ object instance.
 
 | Method | Description |
 | -------------------- | ----------- |
-| `list(params)`       | List products |
+| `list(params)`       | List products. You may also provide `{ category_slug: '...' }`, or `{ category_id: '...' }` to list products by category. |
 | `retrieve(id, data = {})`  | Get a specific product |
 
 ## Categories


### PR DESCRIPTION
While browsing the SDK to filter products by category, I noticed the optional args are missing for the `product.list()` method.

`limit` is also accepted, which I can add, but it may expand the table row further. Unless there's a better way to document the args.