### PR TITLE
Remove unused email argument from getToken() and add about() method

### DIFF
--- a/src/features/customer.js
+++ b/src/features/customer.js
@@ -28,17 +28,13 @@ class Customer {
    * Get access token
    *
    * @see https://commercejs.com/docs/api/#exchange-login-token-for-jwt
-   * @param {string} email The customer's email address
    * @param {string} token The login token from the email sent when using login()
    * @param {boolean} save Whether to save the user in session
    * @returns {Promise}
    */
-  getToken(email, token, save = true) {
+  getToken(token, save = true) {
     return this.commerce
-      .request('customers/exchange-token', 'post', {
-        email,
-        token,
-      })
+      .request('customers/exchange-token', 'post', { token })
       .then(result => {
         if (save && (result.customer_id || result.jwt)) {
           this.data = {
@@ -95,6 +91,15 @@ class Customer {
       {},
       token,
     );
+  }
+
+  /**
+   * Gets information about the currently authorized customer
+   *
+   * @return {Promise}
+   */
+  about() {
+    return this._request(`customers/${this.id()}`);
   }
 
   /**

--- a/src/features/tests/customer-test.js
+++ b/src/features/tests/customer-test.js
@@ -45,19 +45,36 @@ describe('Customer', () => {
     });
   });
 
+  describe('about', () => {
+    it('proxies the request method', () => {
+      const customer = new Customer(mockCommerce);
+      customer.data.id = 'cstmr_QWERTY';
+      customer.data.token = 'ABC-123-ZYX-234';
+      customer.about();
+
+      expect(requestMock).toHaveBeenLastCalledWith(
+        'customers/cstmr_QWERTY',
+        'get',
+        null,
+        {
+          'X-Authorization': undefined,
+          Authorization: 'Bearer ABC-123-ZYX-234',
+        },
+        'ABC-123-ZYX-234',
+      );
+    });
+  });
+
   describe('getToken', () => {
     it('proxies the request method', () => {
       requestMock.mockReturnValue(Promise.resolve({}));
       const customer = new Customer(mockCommerce);
-      customer.getToken('foo@example.com', 'ABC-123-ZYX-234');
+      customer.getToken('ABC-123-ZYX-234');
 
       expect(requestMock).toHaveBeenLastCalledWith(
         'customers/exchange-token',
         'post',
-        {
-          email: 'foo@example.com',
-          token: 'ABC-123-ZYX-234',
-        },
+        { token: 'ABC-123-ZYX-234' },
       );
     });
   });


### PR DESCRIPTION
The email argument is not part of the API endpoint, so isn't required in the SDK API.

Also adds `about()` (matching naming from the merchants feature) to return customer information.
