### PR TITLE
Set default sorting for customer orders

### DIFF
--- a/src/features/customer.js
+++ b/src/features/customer.js
@@ -58,15 +58,24 @@ class Customer {
    * @see https://commercejs.com/docs/api/#list-orders-for-customer
    * @param {string|null} customerId Optional: the customer's ID e.g. cstmr_ABC123, or null to use session
    * @param {string|null} token Optional: access token for the customer, or null to use session
+   * @param {object|null} params Optional
    * @returns {Promise}
    */
-  getOrders(customerId = null, token = null) {
+  getOrders(customerId = null, token = null, params = {}) {
     this._assertArgsProvided(customerId, token);
+
+    if (!params.sortBy) {
+      params.sortBy = 'created';
+    }
+
+    if (!params.sortDirection) {
+      params.sortDirection = 'desc';
+    }
 
     return this._request(
       `customers/${customerId || this.id()}/orders`,
       'get',
-      {},
+      params,
       {},
       token,
     );

--- a/src/features/customer.js
+++ b/src/features/customer.js
@@ -64,18 +64,16 @@ class Customer {
   getOrders(customerId = null, token = null, params = {}) {
     this._assertArgsProvided(customerId, token);
 
-    if (!params.sortBy) {
-      params.sortBy = 'created';
-    }
-
-    if (!params.sortDirection) {
-      params.sortDirection = 'desc';
-    }
+    const requestParams = {
+      sortBy: 'created',
+      sortDirection: 'desc',
+      ...params,
+    };
 
     return this._request(
       `customers/${customerId || this.id()}/orders`,
       'get',
-      params,
+      requestParams,
       {},
       token,
     );

--- a/src/features/tests/customer-test.js
+++ b/src/features/tests/customer-test.js
@@ -82,12 +82,18 @@ describe('Customer', () => {
   describe('getOrders', () => {
     it('proxies the request method', () => {
       const customer = new Customer(mockCommerce);
-      customer.getOrders('cstmr_FOO123', 'ABC-123-ZYX-234');
+      customer.getOrders('cstmr_FOO123', 'ABC-123-ZYX-234', {
+        sortBy: 'created',
+        sortDirection: 'desc',
+      });
 
       expect(requestMock).toHaveBeenLastCalledWith(
         'customers/cstmr_FOO123/orders',
         'get',
-        {},
+        {
+          sortBy: 'created',
+          sortDirection: 'desc',
+        },
         {
           'X-Authorization': undefined,
           Authorization: 'Bearer ABC-123-ZYX-234',
@@ -122,7 +128,10 @@ describe('Customer', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'customers/cstmr_QWERTY/orders',
         'get',
-        {},
+        {
+          sortBy: 'created',
+          sortDirection: 'desc',
+        },
         {
           'X-Authorization': undefined,
           Authorization: 'Bearer ABC-123-ZYX-234',
@@ -139,7 +148,10 @@ describe('Customer', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'customers/cstmr_QWERTY/orders',
         'get',
-        {},
+        {
+          sortBy: 'created',
+          sortDirection: 'desc',
+        },
         {
           'X-Authorization': undefined,
           Authorization: 'Bearer ABC-123-ZYX-234',


### PR DESCRIPTION
This change should return the customer orders by the `created` field in descending order.