### PR TITLE
Increase invalid public key warning to error

### DIFF
--- a/src/commerce.js
+++ b/src/commerce.js
@@ -71,7 +71,7 @@ class Commerce {
     const headers = {
       'X-Authorization': this.options.publicKey,
       'X-Chec-Agent': 'commerce.js/v2',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
     };
 
     // Let axios serialize get request payloads as JSON

--- a/src/commerce.js
+++ b/src/commerce.js
@@ -24,7 +24,7 @@ class Commerce {
     };
 
     if (typeof publicKey !== 'string' || publicKey.length === 0) {
-      console.warn('⚠️ Invalid public key given to Commerce.js client');
+      throw new Error('⚠️ Invalid public key given to Commerce.js client');
     }
 
     if (publicKey.toLowerCase().substring(0, 3) === 'sk_') {


### PR DESCRIPTION
Commerce.js will not function without this, so I do not see increasing this to an error as a breaking change.

This will provide more useful errors to developers, who otherwise see "cannot read property 'toLowerCase' of undefined"
