### PR TITLE
Ensure commerce.js doesn't break when run on a server

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -9,6 +9,10 @@ class Storage {
   }
 
   set(key, value, days) {
+    if (!document) {
+      return null;
+    }
+
     let path;
     let expires = '';
 
@@ -30,6 +34,10 @@ class Storage {
   }
 
   get(key) {
+    if (!document) {
+      return null;
+    }
+
     key = key + '=';
 
     for (let c of Array.from(document.cookie.split(';'))) {


### PR DESCRIPTION
This could be improved by trying to use some cookie library to support it on servers, but this is a quick fix to stop it crashing.