### PR TITLE
Update to support new variant request payload when adding to cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/chec/commercejs-examples/master/assets/logo.svg" width="380" height="100" />
 </p>
 <p align="center">
-Fast, powerful, and easy to use JavaScript SDK for building and managing carts, checkouts and receipts. 
+Fast, powerful, and easy to use JavaScript SDK for building and managing carts, checkouts and receipts.
 Build custom eCommerce experiences to sell physical and digital products from the Chec API.
 </p>
 
@@ -42,6 +42,14 @@ Our documentation module source code resides in `commerce.js/docs`
 If you would like to make contributions to the Commerce.js documentation source, here is a [guide](https://github.com/chec/commerce.js/blob/master/CONTRIBUTING.md) in doing so.
 
 ## Upgrading
+
+### Upgrading to 2.4.0
+
+Commerce.js 2.4.0 only supports API version 2021-03-31 when adding products to a cart with variants. Please consider
+updating your API version, using the changes listed in the [API docs](https://commercejs.com/docs/api/#versioning) as
+a guide.
+
+### Upgrading to 2.0.0
 
 The major change in Commerce.js v2 is that most methods now return a
 [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled

--- a/src/features/cart.js
+++ b/src/features/cart.js
@@ -77,14 +77,41 @@ class Cart {
   /**
    * @param {Object|number} productId
    * @param {number} quantity
-   * @param {Object} variant
+   * @param {Object|string|null} variantData Either a string variant ID, or an object map of (variant) group IDs to
+   *                                         option IDs
    * @returns {Promise}
    */
-  add(productId, quantity = 1, variant = null) {
+  add(productId, quantity = 1, variantData = null) {
+    const validatedVariant = {};
+
+    if (typeof variantData === 'string' && variantData.startsWith('vrnt')) {
+      validatedVariant.variant_id = variantData;
+    } else if (variantData && typeof variantData === 'object') {
+      // Check that keys/values are IDs
+      const validKeys = Object.keys(variantData).every(key =>
+        key.startsWith('vgrp'),
+      );
+      const validValues = Object.values(variantData).every(key =>
+        key.startsWith('optn'),
+      );
+
+      if (!validKeys || !validValues) {
+        throw new Error(
+          'The variant options provided to cart.add do not appear to be a valid map of group IDs to option IDs',
+        );
+      }
+
+      validatedVariant.options = variantData;
+    } else if (variantData) {
+      throw new Error(
+        'Variant data provided to cart.add must be a variant ID, or a map of group IDs to option IDs',
+      );
+    }
+
     const data = {
       id: typeof productId === 'object' ? productId.id : productId,
       quantity,
-      variant,
+      ...validatedVariant,
     };
 
     return this.request('', 'post', data);

--- a/src/features/tests/cart-test.js
+++ b/src/features/tests/cart-test.js
@@ -185,12 +185,12 @@ describe('Cart', () => {
       expect(lastData.id).toBe('bar');
     });
 
-    it('builds a request from given args', async () => {
+    it('builds a request from given args with variant ID', async () => {
       storageGetMock.mockReturnValue('12345');
 
       const cart = new Cart(mockCommerce, '12345');
 
-      await cart.add('id', 6, { variant: 'option' });
+      await cart.add('id', 6, 'vrnt_123');
 
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -202,7 +202,27 @@ describe('Cart', () => {
       const lastData = axios.mock.calls.pop()[0].data;
       expect(lastData.id).toBe('id');
       expect(lastData.quantity).toEqual(6);
-      expect(lastData.variant.variant).toBe('option');
+      expect(lastData.variant_id).toBe('vrnt_123');
+    });
+
+    it('builds a request from given args with variant options', async () => {
+      storageGetMock.mockReturnValue('12345');
+
+      const cart = new Cart(mockCommerce, '12345');
+
+      await cart.add('id', 6, { vgrp_123: 'optn_123' });
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'carts/12345',
+          method: 'post',
+        }),
+      );
+
+      const lastData = axios.mock.calls.pop()[0].data;
+      expect(lastData.id).toBe('id');
+      expect(lastData.quantity).toEqual(6);
+      expect(lastData.options.vgrp_123).toBe('optn_123');
     });
   });
 


### PR DESCRIPTION
Resolves #143

I've added a small section to the readme to cover the new API version required.

While I was looking over the diff, it did occur to me that I can probably still just provide the old `variant` argument as well, and still support the existing method for older versions of the API. Should I do that?