### PR TITLE
getOrders : make default sortBy, API compliant.

### DIFF
--- a/src/features/customer.js
+++ b/src/features/customer.js
@@ -85,7 +85,7 @@ class Customer {
     this._assertArgsProvided(customerId, token);
 
     const requestParams = {
-      sortBy: 'created',
+      sortBy: 'created_at',
       sortDirection: 'desc',
       ...params,
     };


### PR DESCRIPTION
If not overrided, the sortBy param default setted to "created" causes error.