### PR TITLE
Fix bug with CDN deployment on tags that have a "v" prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Detect major version
           command: |
-            export COMMERCE_MAJOR=$(echo $CIRCLE_TAG | sed -r 's/([0-9]+)\..*/\1/')
+            export COMMERCE_MAJOR=$(echo $CIRCLE_TAG | sed -r 's/v?([0-9]+)\..*/\1/')
             echo "Detected major $COMMERCE_MAJOR from tag $CIRCLE_TAG"
             echo "export COMMERCE_MAJOR=$COMMERCE_MAJOR" >> $BASH_ENV
       - run: npm install


### PR DESCRIPTION
This ensures that v1.2.3 and 1.2.3 are both detected as 1 rather than v1

Fixes https://github.com/chec/commerce.js/issues/137
