### PR TITLE
422 validation errors are now listed out in a list to clarify what needs to be resolved

### DIFF
--- a/src/console.js
+++ b/src/console.js
@@ -1,10 +1,7 @@
 const consoleHelper = (color = 'black', a, b, c) => {
   let emoji;
-  let i;
   let isError = false;
-  let len;
   let messages;
-  let results;
 
   switch (color) {
     case 'success':
@@ -17,7 +14,10 @@ const consoleHelper = (color = 'black', a, b, c) => {
       break;
     case 'error':
       color = 'rgba(244, 67, 54, 1)';
-      if (c.error.type === 'validation') {
+      if (
+        c.error.type === 'validation' ||
+        c.error.type === 'unprocessable_entity'
+      ) {
         emoji = '🚫 Validation/missing fields';
         a = '';
       } else {
@@ -37,20 +37,19 @@ const consoleHelper = (color = 'black', a, b, c) => {
         color +
         ';display:block; width: 100%;padding:2px 2px 2px 0px;font-family: Open Sans, Helvetica, Sans-serif;font-weight:bold;background-color:rgba(244, 67, 54, 0.15);',
     );
-    if (typeof c.error.message === 'object') {
-      messages = c.error.message;
-      i = 0;
-      len = messages.length;
-      results = [];
-      while (i < len) {
-        console.log(
-          '%c' + messages[i].field + ' %c' + messages[i].error,
-          'color:#515D6D;font-family: Open Sans, Helvetica, Sans-serif;font-weight:800;',
-          'color:#515D6D;font-family: Open Sans, Helvetica, Sans-serif;font-weight:400;',
-        );
-        results.push(i++);
-      }
-      return results;
+    // 422 validation errors
+    if (typeof c.error.errors === 'object') {
+      messages = c.error.errors;
+      Object.keys(messages).forEach((key, index) => {
+        Object.values(messages[key]).forEach(value => {
+          console.log(
+            '%c' + key + ': %c' + value,
+            'color:#515D6D;font-family: Open Sans, Helvetica, Sans-serif;font-weight:800;',
+            'color:#515D6D;font-family: Open Sans, Helvetica, Sans-serif;font-weight:400;',
+          );
+        });
+      });
+      return;
     }
 
     return console.log(
@@ -83,6 +82,10 @@ const consoleHelper = (color = 'black', a, b, c) => {
 };
 
 const debuggerOnNotice = () => {
+  // Do not run the console debugger notice when in CLI/node context
+  if (window === undefined) {
+    return;
+  }
   const ascii =
     '\r\n \r\n                           Che         EcC\r\n                         c....c2    2c....:C\r\n                       c........c2   2c.....:C\r\n                     c............c2   2c.....:C\r\n                   c................c2   2c.....:C\r\n                 c....................c2   2c.....:C\r\n               c........................c2   2c.....:C\r\n             c............................c2   2c.....:C\r\n           c.......:E2  2c..................c2   2c.....:C\r\n         c........h  $$   2c..................c2   2c.....:C\r\n       c.........:C  $cc$  E....................c2   2c.....:C\r\n     c............h    $$  c......................c2   2c.....:C\r\n   c...............:E    E:.........................c2   2c.....:C\r\n   E............................:C c..................h2   2c...:C\r\n     E........................:C     c..................h2   2hC\r\n       E....................:C         c..................h2\r\n         E................:C             c................:C\r\n           E............:C                 c............:C\r\n             E........:C                     c........:C\r\n               E....:C                         c....:C\r\n                 EcC                             EcC\r\n \r\n \r\n \r\n';
 


### PR DESCRIPTION
Also disables the console debugger notice when used in node.js/CLI context. This prevents massive repeated spam when using Commerce.js in server-side rendering phases e.g. Next.js/Nuxt.

Resolves https://github.com/chec/commerce.js/issues/124
