### PR TITLE
Add typings installation step to Getting started

### DIFF
--- a/docs/00_Getting_started.md
+++ b/docs/00_Getting_started.md
@@ -29,7 +29,9 @@ The only requirement for using Commerce.js is to have Node.js (version 10 or hig
 
 ### Install the SDK with a package manager
 
-If you're using npm or yarn, then adding the Commerce.js SDK to your project is really simple. Once you've created a directory for your project, navigate into your project's root folder in your terminal `cd your-project-folder`, and type the following:
+If you're using npm or yarn, then adding the Commerce.js SDK to your project is really simple. Once you've created a
+directory for your project, navigate into your project's root folder in your terminal `cd your-project-folder`, and type
+the following:
 
 ```bash
 npm install @chec/commerce.js
@@ -42,20 +44,27 @@ yarn add @chec/commerce.js
     <p>Note that examples provided using the Commerce.js SDK are using the latest version - available on <a href="https://www.npmjs.com/package/@chec/commerce.js">npm</a>.</p>
 </div>
 
-### Installing the SDK via our CDN
 
-Another option would be to install the SDK via our CDN, you will need to include this script tag in your point of entry file, for instance in your `index.html`.
+### Install Commerce.js with TypeScript definitions
 
+If you're using TypeScript for your application, Commerce.js has public typings added which you can easily install with
+the Commerce.js library.
+
+```bash
+npm install @chec/commerce.js @types/chec__commerce.js
+# or
+yarn add @chec/commerce.js @types/chec__commerce.js
 ```
-<script type="text/javascript" src="https://cdn.chec.io/v2/commerce.js"></script>
-```
 
-<div class="highlight highlight--info">
-    <span>Tip</span>
-    <p>We recommend installing Commerce.js as a package to have access to all the methods included.</p>
+<div class="highlight highlight--note">
+    <span>Note</span>
+    <p>Note that when using TypeScript, the definitions are always compliant with our latest version of the API. If you specify a custom API version, or your API
+key uses an older version, you may get type errors.</p>
 </div>
 
-We're almost ready to go! We need to create a new Commerce instance and give it our [public key](/docs/sdk/concepts#scope) (you can get your API keys from [Chec Dashboard > Settings > Developer](https://dashboard.chec.io/settings/developer)).
+We're almost ready to go! We need to create a new Commerce instance and give it our [public
+key](/docs/sdk/concepts#scope) (you can get your API keys from [Chec Dashboard > Settings >
+Developer](https://dashboard.chec.io/settings/developer)).
 
 <div class="highlight highlight--info">
     <span>Tip</span>
@@ -75,13 +84,18 @@ const commerce = new Commerce('{public_api_key}');
     <p>We've built in a console debugger into the Commerce.js SDK to help with debugging during development. To enable the debugger you can include the second argument <code>true</code> when you create your Commerce instance like so: <code>const commerce = new Commerce('{public_api_key}', true);</code>. Note that a test API key has to be provided as the first argument for the console to show messages - it won't work with a live key.</p>
 </div>
 
-Awesome, you have set up your Chec account, installed the Commerce.js SDK and created your first Commerce instance! You now have access to the `Commerce` object in your application to build out a truly unique frontend presentation layer!
+Awesome, you have set up your Chec account, installed the Commerce.js SDK and created your first Commerce instance! You
+now have access to the `Commerce` object in your application to build out a truly unique frontend presentation layer!
 
 ---
 
 ### Next steps
 
-Browse through the rest of our documentation to explore all the features of Commerce.js - [listing products](/docs/sdk/products#list-products), [add products to cart](/docs/sdk/cart#add-to-cart), or [capture an order](/docs/sdk/checkout#capture-order). Note that all requests made using the Commerce.js SDK will have responses that are returned asynchronously in a promise. Alternatively, if you want to dive more into reading a high-level overview of Commerce.js and its features, read more [here](/docs/sdk/full-sdk-reference#introduction).
+Browse through the rest of our documentation to explore all the features of Commerce.js - [listing
+products](/docs/sdk/products#list-products), [add products to cart](/docs/sdk/cart#add-to-cart), or [capture an
+order](/docs/sdk/checkout#capture-order). Note that all requests made using the Commerce.js SDK will have responses that
+are returned asynchronously in a promise. Alternatively, if you want to dive more into reading a high-level overview of
+Commerce.js and its features, read more [here](/docs/sdk/full-sdk-reference#introduction).
 
 
 <div class="highlight highlight--warn">

--- a/docs/00_Getting_started.md
+++ b/docs/00_Getting_started.md
@@ -62,6 +62,8 @@ yarn add @chec/commerce.js @types/chec__commerce.js
 key uses an older version, you may get type errors.</p>
 </div>
 
+### Instantiate Commerce with your API key
+
 We're almost ready to go! We need to create a new Commerce instance and give it our [public
 key](/docs/sdk/concepts#scope) (you can get your API keys from [Chec Dashboard > Settings >
 Developer](https://dashboard.chec.io/settings/developer)).


### PR DESCRIPTION
- Added installation step for adding commerce.js typings to getting started docs
- Removed CDN installation method