### PR TITLE
The checkout.protect() method is now deprecated, it will be removed in future

### DIFF
--- a/src/features/checkout.js
+++ b/src/features/checkout.js
@@ -9,13 +9,12 @@ class Checkout {
   }
 
   /**
+   * @deprecated This API no longer exists, the method will be removed in Commerce.js 3.0
    * @param {string} token
    * @return {Promise}
    */
   protect(token) {
-    return this.commerce.request(`checkouts/${token}/protect`).then(
-      data => eval(data.sift_js), // todo remove this, or document if it is safe
-    );
+    return new Promise(resolve => resolve(null));
   }
 
   /**

--- a/src/features/tests/checkout-test.js
+++ b/src/features/tests/checkout-test.js
@@ -38,13 +38,10 @@ beforeEach(() => {
 
 describe('Checkout', () => {
   describe('protect', () => {
-    it('proxies the request method', async () => {
-      requestMock.mockReturnValueOnce(Promise.resolve({}));
-
+    it('returns an empty promise', async () => {
       const checkout = new Checkout(mockCommerce);
-      checkout.protect('foo');
-
-      expect(requestMock).toHaveBeenLastCalledWith('checkouts/foo/protect');
+      const result = await checkout.protect('foo');
+      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
The underlying API will be removed in the `2021-09-22` Chec API release. This change will return an empty promise for backwards compatibility. The method is now deprecated and will be removed in Commerce.js 3.0.

This change requires a minor version release.
