### PR TITLE
customer.about() now accepts an optional customer ID and token for authorization

### DIFF
--- a/src/features/customer.js
+++ b/src/features/customer.js
@@ -56,6 +56,7 @@ class Customer {
    * Update customer
    *
    * @see https://commercejs.com/docs/api/#update-customer
+   * @param {object} data The data to update on the customer
    * @param {string|null} customerId Optional: the customer's ID e.g. cstmr_ABC123, or null to use session
    * @param {string|null} token Optional: access token for the customer, or null to use session
    * @returns {Promise}
@@ -121,12 +122,20 @@ class Customer {
   }
 
   /**
-   * Gets information about the currently authorized customer
+   * Gets information about the currently authorized customer, or a specific customer ID
    *
+   * @param {string|null} customerId Optional: the customer's ID e.g. cstmr_ABC123, or null to use session
+   * @param {string|null} token Optional: access token for the customer, or null to use session
    * @return {Promise}
    */
-  about() {
-    return this._request(`customers/${this.id()}`);
+  about(customerId = null, token = null) {
+    return this._request(
+      `customers/${customerId || this.id()}`,
+      'get',
+      {},
+      {},
+      token,
+    );
   }
 
   /**

--- a/src/features/tests/customer-test.js
+++ b/src/features/tests/customer-test.js
@@ -55,10 +55,25 @@ describe('Customer', () => {
       expect(requestMock).toHaveBeenLastCalledWith(
         'customers/cstmr_QWERTY',
         'get',
-        null,
+        {},
         {
           'X-Authorization': undefined,
           Authorization: 'Bearer ABC-123-ZYX-234',
+        },
+      );
+    });
+
+    it('accepts ID and token arguments', () => {
+      const customer = new Customer(mockCommerce);
+      customer.about('cstmr_ABC123', 'BCD-234-CBD-345');
+
+      expect(requestMock).toHaveBeenLastCalledWith(
+        'customers/cstmr_ABC123',
+        'get',
+        {},
+        {
+          'X-Authorization': undefined,
+          Authorization: 'Bearer BCD-234-CBD-345',
         },
       );
     });


### PR DESCRIPTION
Fixes #216
